### PR TITLE
Deploy to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Poker Range Trainer
 
+🎮 **[Try it live → https://phillyc.github.io/poker_trainer/](https://phillyc.github.io/poker_trainer/)**
+
 A simple Texas Hold'em range selection tool for practicing and visualizing poker starting hand ranges.
 
 ## Quick Start


### PR DESCRIPTION
## What

Adds automated deployment to GitHub Pages via GitHub Actions.

Closes #7

## Changes

- **`.github/workflows/deploy.yml`** — GitHub Actions workflow that deploys the static site to GitHub Pages on every push to `main`. Uses the official `actions/deploy-pages@v4` action. No build step needed since the app is purely static (index.html, app.js, styles.css, presets.json).
- **`README.md`** — Added the live URL at the top: https://phillyc.github.io/poker_trainer/

## How to verify

1. Merge this PR
2. Go to **Settings → Pages** and ensure the source is set to "GitHub Actions"
3. The workflow will run automatically on merge to `main`
4. Visit https://phillyc.github.io/poker_trainer/ to confirm the site is live
5. Check the Actions tab to see the deployment workflow run