### PR TITLE
Refactor: split app.ts into logical modules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -60,17 +60,50 @@ Example preset structure:
 
 - `index.html` - Main HTML file
 - `styles.css` - Styling
-- `app.js` - JavaScript logic (compiled from TypeScript)
-- `app.ts` - TypeScript source code
+- `app.js` - JavaScript logic (bundled from TypeScript modules)
+- `src/` - TypeScript source modules (see [Module Structure](#module-structure))
 - `presets.json` - **Editable preset ranges** (no compilation needed!)
 - `docker-compose.yml` - Docker development environment
 - `Dockerfile.dev` - Development container configuration
 - `package.json` - Node.js dependencies and scripts
 - `PRESETS_README.md` - Guide for editing presets
 
+## Module Structure
+
+The TypeScript source is organized into logical modules under `src/`:
+
+```
+src/
+├── app.ts          # Entry point — imports everything, sets up event listeners, init()
+├── types.ts        # Shared types and interfaces (HandAction, HandCell, SavedRange, etc.)
+├── constants.ts    # Constants (RANKS, STORAGE_KEY, INITIAL_HANDS_COUNT)
+├── state.ts        # Centralized mutable state + setter functions
+├── grid.ts         # Range grid rendering and drag/touch interaction
+├── actions.ts      # Hand action logic (setHandAction, resetAll, selectAll, updateStats)
+├── presets.ts      # Preset loading, rendering, and format handling
+├── storage.ts      # LocalStorage operations (save/load/delete ranges, clipboard)
+├── training.ts     # Training modes (Range Recall + Spot Drill)
+└── ui.ts           # Toast notifications, confirm dialogs, mobile navigation
+```
+
+All modules use ES imports/exports and are bundled into a single `app.js` IIFE via esbuild.
+
 ## Development
 
-### Option 1: Docker Development Environment (Recommended) 🐳
+### Building
+
+```bash
+# Install dependencies
+npm install
+
+# Build app.js from source modules
+npm run build
+
+# Watch mode — rebuilds on file changes
+npm run watch
+```
+
+### Option 1: Docker Development Environment 🐳
 
 **Features:**
 - ✅ Auto-compiling TypeScript on file save
@@ -119,21 +152,15 @@ docker compose down
 docker compose up --build
 ```
 
-### Option 2: Simple Compilation (No Live Reload)
+### Option 2: Local Development (No Docker)
 
-For quick TypeScript compilation without the full dev environment:
-
-**Windows:**
 ```bash
-compile.bat
+npm install
+npm run watch
+# Open index.html in your browser
 ```
 
-**Linux/WSL:**
-```bash
-wsl bash -c "cd /mnt/c/Users/ph1c/dev/poker_trainer && docker build -t poker-trainer-builder . && docker create --name poker-temp poker-trainer-builder && docker cp poker-temp:/app/app.js . && docker rm poker-temp"
-```
-
-### Option 3: No Docker (Static Files Only)
+### Option 3: No Build (Static Files Only)
 
 Simply open `index.html` in your browser. The existing `app.js` file will work as-is.
 
@@ -143,8 +170,19 @@ Simply open `index.html` in your browser. The existing `app.js` file will work a
 poker_trainer/
 ├── index.html              # Main HTML file
 ├── styles.css              # Styling
-├── app.js                  # Compiled JavaScript (DO NOT EDIT - auto-generated)
-├── app.ts                  # TypeScript source (EDIT THIS)
+├── app.js                  # Bundled JavaScript (DO NOT EDIT - auto-generated)
+├── src/                    # TypeScript source modules (EDIT THESE)
+│   ├── app.ts              # Entry point
+│   ├── types.ts            # Type definitions
+│   ├── constants.ts        # Constants
+│   ├── state.ts            # Centralized state management
+│   ├── grid.ts             # Grid rendering & interactions
+│   ├── actions.ts          # Hand action logic
+│   ├── presets.ts          # Preset management
+│   ├── storage.ts          # LocalStorage operations
+│   ├── training.ts         # Training modes
+│   └── ui.ts               # UI utilities
+├── presets.json            # Editable preset ranges
 ├── docker-compose.yml      # Docker development setup
 ├── Dockerfile              # Production build
 ├── Dockerfile.dev          # Development build with watch mode

--- a/app.js
+++ b/app.js
@@ -1,1376 +1,1138 @@
-"use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
+(() => {
+  var __async = (__this, __arguments, generator) => {
+    return new Promise((resolve, reject) => {
+      var fulfilled = (value) => {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      var rejected = (value) => {
+        try {
+          step(generator.throw(value));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
+      step((generator = generator.apply(__this, __arguments)).next());
     });
-};
-// Poker ranks from high to low
-const RANKS = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2'];
-// Store the state of all hands
-const handsState = new Map();
-// Track drag state
-let isDragging = false;
-let dragAction = null;
-let isTouching = false;
-let lastTouchedHand = null;
-// Current edit mode (default to 'raise')
-let currentEditMode = 'raise';
-// LocalStorage key for saved ranges
-const STORAGE_KEY = 'poker-trainer-saved-ranges';
-// Store loaded presets
-let loadedPresets = {};
-let currentMode = 'edit';
-let currentTrainingMode = 'range-recall';
-let trainingRange = null;
-let trainingRangeName = '';
-let trainingRangeDescription = '';
-let currentLoadedPresetKey = '';
-let spotDrillState = null;
-const INITIAL_HANDS_COUNT = 5;
-/**
- * Determine the hand label and type based on grid position
- */
-function getHandInfo(row, col) {
+  };
+
+  // src/state.ts
+  var handsState = /* @__PURE__ */ new Map();
+  var isDragging = false;
+  var dragAction = null;
+  var isTouching = false;
+  var lastTouchedHand = null;
+  var currentEditMode = "raise";
+  var loadedPresets = {};
+  var currentMode = "edit";
+  var currentTrainingMode = "range-recall";
+  var trainingRange = null;
+  var trainingRangeName = "";
+  var trainingRangeDescription = "";
+  var currentLoadedPresetKey = "";
+  var spotDrillState = null;
+  function setIsDragging(value) {
+    isDragging = value;
+  }
+  function setDragAction(value) {
+    dragAction = value;
+  }
+  function setIsTouching(value) {
+    isTouching = value;
+  }
+  function setLastTouchedHand(value) {
+    lastTouchedHand = value;
+  }
+  function setCurrentEditMode(value) {
+    currentEditMode = value;
+  }
+  function setLoadedPresets(value) {
+    loadedPresets = value;
+  }
+  function setCurrentMode(value) {
+    currentMode = value;
+  }
+  function setCurrentTrainingMode(value) {
+    currentTrainingMode = value;
+  }
+  function setTrainingRange(value) {
+    trainingRange = value;
+  }
+  function setTrainingRangeName(value) {
+    trainingRangeName = value;
+  }
+  function setTrainingRangeDescription(value) {
+    trainingRangeDescription = value;
+  }
+  function setCurrentLoadedPresetKey(value) {
+    currentLoadedPresetKey = value;
+  }
+  function setSpotDrillState(value) {
+    spotDrillState = value;
+  }
+
+  // src/actions.ts
+  function setHandAction(hand, action) {
+    const handState = handsState.get(hand);
+    if (!handState)
+      return;
+    if (handState.action === action)
+      return;
+    handState.action = action;
+    const cell = document.querySelector(`[data-hand="${hand}"]`);
+    if (cell) {
+      cell.classList.remove("action-fold", "action-raise", "action-call", "action-mix-rc", "action-mix-rf");
+      cell.classList.add(`action-${action}`);
+    }
+    updateStats();
+  }
+  function setEditMode(action) {
+    setCurrentEditMode(action);
+    const buttons = document.querySelectorAll(".edit-mode-btn");
+    buttons.forEach((btn) => {
+      const button = btn;
+      if (button.dataset.action === action) {
+        button.classList.add("active");
+      } else {
+        button.classList.remove("active");
+      }
+    });
+  }
+  function updateStats() {
+    const raiseCount = Array.from(handsState.values()).filter((h) => h.action === "raise").length;
+    const callCount = Array.from(handsState.values()).filter((h) => h.action === "call").length;
+    const mixRcCount = Array.from(handsState.values()).filter((h) => h.action === "mix-rc").length;
+    const mixRfCount = Array.from(handsState.values()).filter((h) => h.action === "mix-rf").length;
+    const totalSelected = raiseCount + callCount + mixRcCount + mixRfCount;
+    const totalHands = 169;
+    const percentage = (totalSelected / totalHands * 100).toFixed(1);
+    const raisePercentage = (raiseCount / totalHands * 100).toFixed(1);
+    const callPercentage = (callCount / totalHands * 100).toFixed(1);
+    const mixRcPercentage = (mixRcCount / totalHands * 100).toFixed(1);
+    const mixRfPercentage = (mixRfCount / totalHands * 100).toFixed(1);
+    const countElement = document.getElementById("selected-count");
+    if (countElement) {
+      countElement.textContent = `${percentage}% (Raise: ${raisePercentage}%, Call: ${callPercentage}%, Mix RC: ${mixRcPercentage}%, Mix RF: ${mixRfPercentage}%) - ${totalSelected} / ${totalHands}`;
+    }
+  }
+  function resetAll() {
+    handsState.forEach((handState) => {
+      if (handState.action !== "fold") {
+        setHandAction(handState.hand, "fold");
+      }
+      const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
+      if (cell) {
+        cell.classList.remove("train-correct", "train-incorrect", "train-missed");
+      }
+    });
+  }
+  function selectAll() {
+    handsState.forEach((handState) => {
+      if (handState.action !== "raise") {
+        setHandAction(handState.hand, "raise");
+      }
+    });
+  }
+  function getCurrentSelection() {
+    const selected = {};
+    handsState.forEach((handState) => {
+      if (handState.action !== "fold") {
+        selected[handState.hand] = handState.action;
+      }
+    });
+    return selected;
+  }
+
+  // src/constants.ts
+  var RANKS = ["A", "K", "Q", "J", "T", "9", "8", "7", "6", "5", "4", "3", "2"];
+  var STORAGE_KEY = "poker-trainer-saved-ranges";
+  var INITIAL_HANDS_COUNT = 5;
+
+  // src/grid.ts
+  function getHandInfo(row, col) {
     const rank1 = RANKS[row];
     const rank2 = RANKS[col];
     if (row === col) {
-        // Diagonal: Pocket pairs
-        return { hand: `${rank1}${rank2}`, type: 'pair' };
+      return { hand: `${rank1}${rank2}`, type: "pair" };
+    } else if (row < col) {
+      return { hand: `${rank1}${rank2}s`, type: "suited" };
+    } else {
+      return { hand: `${rank2}${rank1}o`, type: "offsuit" };
     }
-    else if (row < col) {
-        // Above diagonal: Suited hands
-        return { hand: `${rank1}${rank2}s`, type: 'suited' };
-    }
-    else {
-        // Below diagonal: Offsuit hands
-        return { hand: `${rank2}${rank1}o`, type: 'offsuit' };
-    }
-}
-/**
- * Create and render the range grid
- */
-function createRangeGrid() {
-    const gridContainer = document.getElementById('range-grid');
-    if (!gridContainer)
-        return;
-    // Create 13x13 grid
-    for (let row = 0; row < 13; row++) {
-        for (let col = 0; col < 13; col++) {
-            const { hand, type } = getHandInfo(row, col);
-            // Create cell element
-            const cell = document.createElement('div');
-            cell.className = 'hand-cell';
-            cell.textContent = hand;
-            cell.dataset.hand = hand;
-            // Add mouse event listeners for click and drag
-            cell.addEventListener('mousedown', (e) => handleMouseDown(hand, e));
-            cell.addEventListener('mouseenter', () => handleMouseEnter(hand));
-            // Add touch event listeners for mobile
-            cell.addEventListener('touchstart', (e) => handleTouchStart(hand, e), { passive: false });
-            cell.addEventListener('touchmove', (e) => handleTouchMove(hand, e), { passive: false });
-            cell.addEventListener('touchend', () => handleTouchEnd());
-            // Prevent default drag behavior
-            cell.addEventListener('dragstart', (e) => e.preventDefault());
-            gridContainer.appendChild(cell);
-            // Initialize hand state
-            handsState.set(hand, { hand, type, action: 'fold' });
-        }
-    }
-}
-/**
- * Handle mouse down on a cell - start drag operation
- */
-function handleMouseDown(hand, event) {
+  }
+  function handleMouseDown(hand, event) {
     event.preventDefault();
     const handState = handsState.get(hand);
     if (!handState)
-        return;
-    isDragging = true;
-    // Use the currently selected edit mode
-    dragAction = currentEditMode;
-    // Apply action to the clicked cell
+      return;
+    setIsDragging(true);
+    setDragAction(currentEditMode);
     setHandAction(hand, currentEditMode);
-}
-/**
- * Set the current edit mode
- */
-function setEditMode(action) {
-    currentEditMode = action;
-    // Update button states
-    const buttons = document.querySelectorAll('.edit-mode-btn');
-    buttons.forEach((btn) => {
-        const button = btn;
-        if (button.dataset.action === action) {
-            button.classList.add('active');
-        }
-        else {
-            button.classList.remove('active');
-        }
-    });
-}
-/**
- * Handle mouse enter on a cell during drag
- */
-function handleMouseEnter(hand) {
+  }
+  function handleMouseEnter(hand) {
     if (!isDragging || dragAction === null)
-        return;
-    // Apply the drag action to this cell
+      return;
     setHandAction(hand, dragAction);
-}
-/**
- * Handle touch start on a cell
- */
-function handleTouchStart(hand, event) {
+  }
+  function handleTouchStart(hand, event) {
     event.preventDefault();
-    isTouching = true;
-    lastTouchedHand = hand;
+    setIsTouching(true);
+    setLastTouchedHand(hand);
     const handState = handsState.get(hand);
     if (!handState)
-        return;
-    isDragging = true;
-    dragAction = currentEditMode;
-    // Apply action to the touched cell
+      return;
+    setIsDragging(true);
+    setDragAction(currentEditMode);
     setHandAction(hand, currentEditMode);
-}
-/**
- * Handle touch move on a cell
- */
-function handleTouchMove(hand, event) {
+  }
+  function handleTouchMove(hand, event) {
     if (!isTouching || !isDragging || dragAction === null)
-        return;
+      return;
     event.preventDefault();
-    // Get the element under the touch point
     const touch = event.touches[0];
     const element = document.elementFromPoint(touch.clientX, touch.clientY);
-    if (element && element.classList.contains('hand-cell')) {
-        const touchedHand = element.getAttribute('data-hand');
-        if (touchedHand && touchedHand !== lastTouchedHand) {
-            lastTouchedHand = touchedHand;
-            setHandAction(touchedHand, dragAction);
-        }
+    if (element && element.classList.contains("hand-cell")) {
+      const touchedHand = element.getAttribute("data-hand");
+      if (touchedHand && touchedHand !== lastTouchedHand) {
+        setLastTouchedHand(touchedHand);
+        setHandAction(touchedHand, dragAction);
+      }
     }
-}
-/**
- * Handle touch end
- */
-function handleTouchEnd() {
-    isTouching = false;
-    isDragging = false;
-    dragAction = null;
-    lastTouchedHand = null;
-}
-/**
- * Set action state of a hand
- */
-function setHandAction(hand, action) {
-    const handState = handsState.get(hand);
-    if (!handState)
-        return;
-    // Only update if state is changing
-    if (handState.action === action)
-        return;
-    handState.action = action;
-    // Update UI
-    const cell = document.querySelector(`[data-hand="${hand}"]`);
-    if (cell) {
-        // Remove all action classes
-        cell.classList.remove('action-fold', 'action-raise', 'action-call', 'action-mix-rc', 'action-mix-rf');
-        // Add appropriate class
-        cell.classList.add(`action-${action}`);
+  }
+  function handleTouchEnd() {
+    setIsTouching(false);
+    setIsDragging(false);
+    setDragAction(null);
+    setLastTouchedHand(null);
+  }
+  function createRangeGrid() {
+    const gridContainer = document.getElementById("range-grid");
+    if (!gridContainer)
+      return;
+    for (let row = 0; row < 13; row++) {
+      for (let col = 0; col < 13; col++) {
+        const { hand, type } = getHandInfo(row, col);
+        const cell = document.createElement("div");
+        cell.className = "hand-cell";
+        cell.textContent = hand;
+        cell.dataset.hand = hand;
+        cell.addEventListener("mousedown", (e) => handleMouseDown(hand, e));
+        cell.addEventListener("mouseenter", () => handleMouseEnter(hand));
+        cell.addEventListener("touchstart", (e) => handleTouchStart(hand, e), { passive: false });
+        cell.addEventListener("touchmove", (e) => handleTouchMove(hand, e), { passive: false });
+        cell.addEventListener("touchend", () => handleTouchEnd());
+        cell.addEventListener("dragstart", (e) => e.preventDefault());
+        gridContainer.appendChild(cell);
+        handsState.set(hand, { hand, type, action: "fold" });
+      }
     }
-    // Update stats
-    updateStats();
-}
-/**
- * Update the selection statistics display
- */
-function updateStats() {
-    const raiseCount = Array.from(handsState.values()).filter(h => h.action === 'raise').length;
-    const callCount = Array.from(handsState.values()).filter(h => h.action === 'call').length;
-    const mixRcCount = Array.from(handsState.values()).filter(h => h.action === 'mix-rc').length;
-    const mixRfCount = Array.from(handsState.values()).filter(h => h.action === 'mix-rf').length;
-    const totalSelected = raiseCount + callCount + mixRcCount + mixRfCount;
-    const totalHands = 169;
-    const percentage = ((totalSelected / totalHands) * 100).toFixed(1);
-    const raisePercentage = ((raiseCount / totalHands) * 100).toFixed(1);
-    const callPercentage = ((callCount / totalHands) * 100).toFixed(1);
-    const mixRcPercentage = ((mixRcCount / totalHands) * 100).toFixed(1);
-    const mixRfPercentage = ((mixRfCount / totalHands) * 100).toFixed(1);
-    const countElement = document.getElementById('selected-count');
-    if (countElement) {
-        countElement.textContent = `${percentage}% (Raise: ${raisePercentage}%, Call: ${callPercentage}%, Mix RC: ${mixRcPercentage}%, Mix RF: ${mixRfPercentage}%) - ${totalSelected} / ${totalHands}`;
-    }
-}
-/**
- * Reset all hands to fold state
- */
-function resetAll() {
-    handsState.forEach((handState) => {
-        if (handState.action !== 'fold') {
-            setHandAction(handState.hand, 'fold');
+  }
+
+  // src/presets.ts
+  function loadPresetsFromFile() {
+    return __async(this, null, function* () {
+      try {
+        const response = yield fetch("presets.json");
+        if (!response.ok) {
+          console.error("Failed to load presets.json");
+          return;
         }
-        // Clear any training feedback classes
-        const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
-        if (cell) {
-            cell.classList.remove('train-correct', 'train-incorrect', 'train-missed');
-        }
+        setLoadedPresets(yield response.json());
+        console.log("Presets loaded successfully:", Object.keys(loadedPresets));
+        renderPresetButtons();
+      } catch (error) {
+        console.error("Error loading presets:", error);
+      }
     });
-}
-/**
- * Select all hands as raise
- */
-function selectAll() {
-    handsState.forEach((handState) => {
-        if (handState.action !== 'raise') {
-            setHandAction(handState.hand, 'raise');
-        }
-    });
-}
-/**
- * Load presets from JSON file
- */
-function loadPresetsFromFile() {
-    return __awaiter(this, void 0, void 0, function* () {
-        try {
-            const response = yield fetch('presets.json');
-            if (!response.ok) {
-                console.error('Failed to load presets.json');
-                return;
-            }
-            loadedPresets = yield response.json();
-            console.log('Presets loaded successfully:', Object.keys(loadedPresets));
-            // Render preset buttons after loading
-            renderPresetButtons();
-        }
-        catch (error) {
-            console.error('Error loading presets:', error);
-        }
-    });
-}
-/**
- * Render preset buttons dynamically from loaded presets
- */
-function renderPresetButtons() {
-    const container = document.getElementById('presets-container');
+  }
+  function renderPresetButtons() {
+    const container = document.getElementById("presets-container");
     if (!container)
-        return;
-    // Clear existing buttons
-    container.innerHTML = '';
-    // Get all preset keys and sort them for consistent ordering
+      return;
+    container.innerHTML = "";
     const presetKeys = Object.keys(loadedPresets).sort();
     if (presetKeys.length === 0) {
-        container.innerHTML = '<p class="empty-message">No presets available</p>';
-        return;
+      container.innerHTML = '<p class="empty-message">No presets available</p>';
+      return;
     }
-    // Create a button for each preset
     presetKeys.forEach((presetKey) => {
-        const preset = loadedPresets[presetKey];
-        const button = document.createElement('button');
-        button.className = 'preset-button';
-        button.dataset.preset = presetKey;
-        button.textContent = preset.name || presetKey;
-        button.title = preset.description || `Load ${preset.name || presetKey}`;
-        container.appendChild(button);
+      const preset = loadedPresets[presetKey];
+      const button = document.createElement("button");
+      button.className = "preset-button";
+      button.dataset.preset = presetKey;
+      button.textContent = preset.name || presetKey;
+      button.title = preset.description || `Load ${preset.name || presetKey}`;
+      container.appendChild(button);
     });
-}
-/**
- * Load a preset range
- */
-function loadPreset(presetName) {
+  }
+  function loadPreset(presetName) {
     const preset = loadedPresets[presetName];
     if (!preset) {
-        console.warn(`Preset "${presetName}" not found`);
-        return;
+      console.warn(`Preset "${presetName}" not found`);
+      return;
     }
-    // Store the current preset info for train mode
-    currentLoadedPresetKey = presetName;
-    // Check format type
+    setCurrentLoadedPresetKey(presetName);
     if (Array.isArray(preset.hands)) {
-        // Format 1: Simple array - all hands are raise
-        loadHandsArray(preset.hands);
+      loadHandsArray(preset.hands);
+    } else if (typeof preset.hands === "object") {
+      const firstKey = Object.keys(preset.hands)[0];
+      const firstValue = preset.hands[firstKey];
+      if (Array.isArray(firstValue)) {
+        loadHandsGroupedByAction(preset.hands);
+      } else {
+        loadHandsWithActions(preset.hands);
+      }
     }
-    else if (typeof preset.hands === 'object') {
-        // Check if it's Format 2 (hand->action) or Format 3 (action->hands[])
-        const firstKey = Object.keys(preset.hands)[0];
-        const firstValue = preset.hands[firstKey];
-        if (Array.isArray(firstValue)) {
-            // Format 3: Grouped by action {"raise": ["AA", "KK"], "call": ["QQ"]}
-            loadHandsGroupedByAction(preset.hands);
-        }
-        else {
-            // Format 2: Hand to action mapping {"AA": "raise", "KK": "call"}
-            loadHandsWithActions(preset.hands);
-        }
-    }
-}
-/**
- * Load hands grouped by action (new format)
- */
-function loadHandsGroupedByAction(groupedHands) {
-    // First clear all
+  }
+  function loadHandsGroupedByAction(groupedHands) {
     resetAll();
-    // Then apply each action group
     Object.keys(groupedHands).forEach((action) => {
-        const hands = groupedHands[action];
-        if (Array.isArray(hands)) {
-            hands.forEach((hand) => {
-                const handState = handsState.get(hand);
-                // Support legacy 'mix' as 'mix-rc' for backward compatibility
-                const normalizedAction = action === 'mix' ? 'mix-rc' : action;
-                if (handState && (normalizedAction === 'raise' || normalizedAction === 'call' || normalizedAction === 'mix-rc' || normalizedAction === 'mix-rf' || normalizedAction === 'fold')) {
-                    setHandAction(hand, normalizedAction);
-                }
-            });
-        }
+      const hands = groupedHands[action];
+      if (Array.isArray(hands)) {
+        hands.forEach((hand) => {
+          const handState = handsState.get(hand);
+          const normalizedAction = action === "mix" ? "mix-rc" : action;
+          if (handState && (normalizedAction === "raise" || normalizedAction === "call" || normalizedAction === "mix-rc" || normalizedAction === "mix-rf" || normalizedAction === "fold")) {
+            setHandAction(hand, normalizedAction);
+          }
+        });
+      }
     });
-}
-/**
- * Load a specific array of hands (legacy format - all as raise)
- */
-function loadHandsArray(hands) {
-    // First clear all
+  }
+  function loadHandsArray(hands) {
     resetAll();
-    // Then select the specified hands as raise
     hands.forEach((hand) => {
-        const handState = handsState.get(hand);
-        if (handState) {
-            setHandAction(hand, 'raise');
-        }
+      const handState = handsState.get(hand);
+      if (handState) {
+        setHandAction(hand, "raise");
+      }
     });
-}
-/**
- * Load hands with specific actions
- */
-function loadHandsWithActions(handsMap) {
-    // First clear all
+  }
+  function loadHandsWithActions(handsMap) {
     resetAll();
-    // Then apply actions
     Object.keys(handsMap).forEach((hand) => {
-        const action = handsMap[hand];
-        const handState = handsState.get(hand);
-        if (handState && action !== 'fold') {
-            setHandAction(hand, action);
-        }
+      const action = handsMap[hand];
+      const handState = handsState.get(hand);
+      if (handState && action !== "fold") {
+        setHandAction(hand, action);
+      }
     });
-}
-/**
- * Get currently selected hands with their actions
- */
-function getCurrentSelection() {
-    const selected = {};
-    handsState.forEach((handState) => {
-        if (handState.action !== 'fold') {
-            selected[handState.hand] = handState.action;
+  }
+
+  // src/ui.ts
+  function showToast(message, type) {
+    const container = document.getElementById("toast-container");
+    if (!container)
+      return;
+    const toast = document.createElement("div");
+    toast.className = `toast toast-${type}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add("show");
+    }, 10);
+    setTimeout(() => {
+      toast.classList.remove("show");
+      setTimeout(() => {
+        container.removeChild(toast);
+      }, 300);
+    }, 2e3);
+  }
+  function showConfirm(message) {
+    return new Promise((resolve) => {
+      const overlay = document.createElement("div");
+      overlay.className = "confirm-modal-overlay";
+      const modal = document.createElement("div");
+      modal.className = "confirm-modal";
+      const messageDiv = document.createElement("div");
+      messageDiv.className = "confirm-message";
+      messageDiv.textContent = message;
+      const buttonsDiv = document.createElement("div");
+      buttonsDiv.className = "confirm-buttons";
+      const confirmBtn = document.createElement("button");
+      confirmBtn.className = "confirm-btn confirm-btn-ok";
+      confirmBtn.textContent = "OK";
+      confirmBtn.addEventListener("click", () => {
+        document.body.removeChild(overlay);
+        resolve(true);
+      });
+      const cancelBtn = document.createElement("button");
+      cancelBtn.className = "confirm-btn confirm-btn-cancel";
+      cancelBtn.textContent = "Cancel";
+      cancelBtn.addEventListener("click", () => {
+        document.body.removeChild(overlay);
+        resolve(false);
+      });
+      buttonsDiv.appendChild(confirmBtn);
+      buttonsDiv.appendChild(cancelBtn);
+      modal.appendChild(messageDiv);
+      modal.appendChild(buttonsDiv);
+      overlay.appendChild(modal);
+      document.body.appendChild(overlay);
+      setTimeout(() => {
+        overlay.classList.add("show");
+      }, 10);
+      const handleEscape = (e) => {
+        if (e.key === "Escape") {
+          document.body.removeChild(overlay);
+          document.removeEventListener("keydown", handleEscape);
+          resolve(false);
         }
+      };
+      document.addEventListener("keydown", handleEscape);
     });
-    return selected;
-}
-/**
- * Get all saved ranges from localStorage
- */
-function getSavedRanges() {
-    try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (!stored)
-            return [];
-        return JSON.parse(stored);
+  }
+  function setupMobileNavigation() {
+    const mobileNavToggle = document.getElementById("mobile-nav-toggle");
+    const navBar = document.getElementById("nav-bar");
+    const navBackdrop = document.getElementById("nav-backdrop");
+    const hamburgerIcon = mobileNavToggle == null ? void 0 : mobileNavToggle.querySelector(".hamburger-icon");
+    const closeIcon = mobileNavToggle == null ? void 0 : mobileNavToggle.querySelector(".close-icon");
+    if (!mobileNavToggle || !navBar || !navBackdrop)
+      return;
+    function openNav() {
+      navBar.classList.add("mobile-open");
+      navBackdrop.classList.add("show");
+      if (hamburgerIcon)
+        hamburgerIcon.style.display = "none";
+      if (closeIcon)
+        closeIcon.style.display = "block";
+      document.body.style.overflow = "hidden";
     }
-    catch (error) {
-        console.error('Error reading saved ranges:', error);
+    function closeNav() {
+      navBar.classList.remove("mobile-open");
+      navBackdrop.classList.remove("show");
+      if (hamburgerIcon)
+        hamburgerIcon.style.display = "block";
+      if (closeIcon)
+        closeIcon.style.display = "none";
+      document.body.style.overflow = "";
+    }
+    mobileNavToggle.addEventListener("click", () => {
+      if (navBar.classList.contains("mobile-open")) {
+        closeNav();
+      } else {
+        openNav();
+      }
+    });
+    navBackdrop.addEventListener("click", () => {
+      closeNav();
+    });
+    const navButtons = navBar.querySelectorAll(".nav-button, .preset-button, .mode-toggle-btn");
+    navButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        setTimeout(() => {
+          closeNav();
+        }, 300);
+      });
+    });
+    window.addEventListener("resize", () => {
+      if (window.innerWidth > 768) {
+        closeNav();
+      }
+    });
+  }
+
+  // src/storage.ts
+  function getSavedRanges() {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored)
         return [];
+      return JSON.parse(stored);
+    } catch (error) {
+      console.error("Error reading saved ranges:", error);
+      return [];
     }
-}
-/**
- * Save ranges to localStorage
- */
-function saveSavedRanges(ranges) {
+  }
+  function saveSavedRanges(ranges) {
     try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(ranges));
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(ranges));
+    } catch (error) {
+      console.error("Error saving ranges:", error);
+      showToast("Failed to save range. Storage may be full or disabled.", "error");
     }
-    catch (error) {
-        console.error('Error saving ranges:', error);
-        showToast('Failed to save range. Storage may be full or disabled.', 'error');
-    }
-}
-/**
- * Save current selection as a named range
- */
-function saveCurrentRange(name) {
+  }
+  function saveCurrentRange(name) {
     if (!name.trim()) {
-        showToast('Please enter a name for your range.', 'error');
-        return;
+      showToast("Please enter a name for your range.", "error");
+      return;
     }
     const selected = getCurrentSelection();
     if (Object.keys(selected).length === 0) {
-        showToast('Please select at least one hand before saving.', 'error');
-        return;
+      showToast("Please select at least one hand before saving.", "error");
+      return;
     }
     const ranges = getSavedRanges();
-    // Check if name already exists
-    const existingIndex = ranges.findIndex(r => r.name === name.trim());
+    const existingIndex = ranges.findIndex((r) => r.name === name.trim());
     const newRange = {
-        name: name.trim(),
-        hands: selected,
-        timestamp: Date.now()
+      name: name.trim(),
+      hands: selected,
+      timestamp: Date.now()
     };
     if (existingIndex >= 0) {
-        // Update existing range - use async confirmation
-        showConfirm(`A range named "${name.trim()}" already exists. Overwrite it?`).then((confirmed) => {
-            if (confirmed) {
-                // Get fresh ranges to avoid race conditions
-                const currentRanges = getSavedRanges();
-                const currentIndex = currentRanges.findIndex(r => r.name === name.trim());
-                if (currentIndex >= 0) {
-                    currentRanges[currentIndex] = newRange;
-                }
-                else {
-                    currentRanges.push(newRange);
-                }
-                saveSavedRanges(currentRanges);
-                renderSavedRanges();
-                // Clear input field
-                const input = document.getElementById('range-name-input');
-                if (input) {
-                    input.value = '';
-                }
-                showToast(`Range "${name.trim()}" saved successfully!`, 'success');
-            }
-        });
-        return;
-    }
-    else {
-        // Add new range
-        ranges.push(newRange);
+      showConfirm(`A range named "${name.trim()}" already exists. Overwrite it?`).then((confirmed) => {
+        if (confirmed) {
+          const currentRanges = getSavedRanges();
+          const currentIndex = currentRanges.findIndex((r) => r.name === name.trim());
+          if (currentIndex >= 0) {
+            currentRanges[currentIndex] = newRange;
+          } else {
+            currentRanges.push(newRange);
+          }
+          saveSavedRanges(currentRanges);
+          renderSavedRanges();
+          const input2 = document.getElementById("range-name-input");
+          if (input2) {
+            input2.value = "";
+          }
+          showToast(`Range "${name.trim()}" saved successfully!`, "success");
+        }
+      });
+      return;
+    } else {
+      ranges.push(newRange);
     }
     saveSavedRanges(ranges);
     renderSavedRanges();
-    // Clear input field
-    const input = document.getElementById('range-name-input');
+    const input = document.getElementById("range-name-input");
     if (input) {
-        input.value = '';
+      input.value = "";
     }
-    showToast(`Range "${name.trim()}" saved successfully!`, 'success');
-}
-/**
- * Load a saved range
- */
-function loadSavedRange(name) {
+    showToast(`Range "${name.trim()}" saved successfully!`, "success");
+  }
+  function loadSavedRange(name) {
     const ranges = getSavedRanges();
-    const range = ranges.find(r => r.name === name);
+    const range = ranges.find((r) => r.name === name);
     if (range) {
-        // Check if it's the new format (object) or old format (array)
-        if (Array.isArray(range.hands)) {
-            // Legacy format - convert to raise actions
-            loadHandsArray(range.hands);
-        }
-        else {
-            // New format with actions
-            loadHandsWithActions(range.hands);
-        }
+      if (Array.isArray(range.hands)) {
+        loadHandsArray(range.hands);
+      } else {
+        loadHandsWithActions(range.hands);
+      }
     }
-}
-/**
- * Delete a saved range
- */
-function deleteSavedRange(name) {
+  }
+  function deleteSavedRange(name) {
     showConfirm(`Are you sure you want to delete "${name}"?`).then((confirmed) => {
-        if (confirmed) {
-            const ranges = getSavedRanges();
-            const filtered = ranges.filter(r => r.name !== name);
-            saveSavedRanges(filtered);
-            renderSavedRanges();
-            showToast(`Range "${name}" deleted successfully.`, 'success');
-        }
+      if (confirmed) {
+        const ranges = getSavedRanges();
+        const filtered = ranges.filter((r) => r.name !== name);
+        saveSavedRanges(filtered);
+        renderSavedRanges();
+        showToast(`Range "${name}" deleted successfully.`, "success");
+      }
     });
-}
-/**
- * Convert a saved range to presets.json compatible format
- */
-function formatRangeForPresets(range) {
-    // Group hands by action (exclude fold actions)
+  }
+  function formatRangeForPresets(range) {
     const groupedByAction = {
-        raise: [],
-        call: [],
-        'mix-rc': [],
-        'mix-rf': []
+      raise: [],
+      call: [],
+      "mix-rc": [],
+      "mix-rf": []
     };
-    // Handle both old format (array) and new format (object)
     if (Array.isArray(range.hands)) {
-        // Legacy format - all hands are raise
-        groupedByAction.raise = range.hands;
+      groupedByAction.raise = range.hands;
+    } else {
+      Object.keys(range.hands).forEach((hand) => {
+        const action = range.hands[hand];
+        if (action !== "fold" && groupedByAction[action]) {
+          groupedByAction[action].push(hand);
+        }
+      });
     }
-    else {
-        // New format with actions
-        Object.keys(range.hands).forEach((hand) => {
-            const action = range.hands[hand];
-            if (action !== 'fold' && groupedByAction[action]) {
-                groupedByAction[action].push(hand);
-            }
-        });
-    }
-    // Create preset object matching presets.json structure
     const preset = {
-        name: range.name,
-        description: `Custom range: ${range.name}`,
-        hands: groupedByAction
+      name: range.name,
+      description: `Custom range: ${range.name}`,
+      hands: groupedByAction
     };
-    // Generate a key from the range name (lowercase, replace spaces with hyphens)
-    const key = range.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-    // Format as JSON with proper indentation, including the key
-    // This makes it easy to paste directly into presets.json
+    const key = range.name.toLowerCase().replace(/\s+/g, "-").replace(/[^a-z0-9-]/g, "");
     const presetWithKey = {
-        [key]: preset
+      [key]: preset
     };
     return JSON.stringify(presetWithKey, null, 2);
-}
-/**
- * Copy a saved range to clipboard as presets.json compatible JSON
- */
-function copyRangeToClipboard(name) {
-    return __awaiter(this, void 0, void 0, function* () {
-        const ranges = getSavedRanges();
-        const range = ranges.find(r => r.name === name);
-        if (!range) {
-            showToast(`Range "${name}" not found.`, 'error');
-            return;
-        }
-        try {
-            const jsonString = formatRangeForPresets(range);
-            yield navigator.clipboard.writeText(jsonString);
-            showToast(`Range "${name}" copied to clipboard! You can now paste it into presets.json`, 'success');
-        }
-        catch (error) {
-            console.error('Failed to copy to clipboard:', error);
-            // Fallback for older browsers
-            const textArea = document.createElement('textarea');
-            textArea.value = formatRangeForPresets(range);
-            textArea.style.position = 'fixed';
-            textArea.style.opacity = '0';
-            document.body.appendChild(textArea);
-            textArea.select();
-            try {
-                document.execCommand('copy');
-                showToast(`Range "${name}" copied to clipboard! You can now paste it into presets.json`, 'success');
-            }
-            catch (fallbackError) {
-                showToast('Failed to copy to clipboard. Please check your browser permissions.', 'error');
-            }
-            document.body.removeChild(textArea);
-        }
-    });
-}
-/**
- * Render the list of saved ranges
- */
-function renderSavedRanges() {
-    const container = document.getElementById('saved-ranges-list');
-    if (!container)
+  }
+  function copyRangeToClipboard(name) {
+    return __async(this, null, function* () {
+      const ranges = getSavedRanges();
+      const range = ranges.find((r) => r.name === name);
+      if (!range) {
+        showToast(`Range "${name}" not found.`, "error");
         return;
+      }
+      try {
+        const jsonString = formatRangeForPresets(range);
+        yield navigator.clipboard.writeText(jsonString);
+        showToast(`Range "${name}" copied to clipboard! You can now paste it into presets.json`, "success");
+      } catch (error) {
+        console.error("Failed to copy to clipboard:", error);
+        const textArea = document.createElement("textarea");
+        textArea.value = formatRangeForPresets(range);
+        textArea.style.position = "fixed";
+        textArea.style.opacity = "0";
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+          document.execCommand("copy");
+          showToast(`Range "${name}" copied to clipboard! You can now paste it into presets.json`, "success");
+        } catch (fallbackError) {
+          showToast("Failed to copy to clipboard. Please check your browser permissions.", "error");
+        }
+        document.body.removeChild(textArea);
+      }
+    });
+  }
+  function renderSavedRanges() {
+    const container = document.getElementById("saved-ranges-list");
+    if (!container)
+      return;
     const ranges = getSavedRanges();
     if (ranges.length === 0) {
-        container.innerHTML = '<p class="empty-message">No saved ranges yet</p>';
-        return;
+      container.innerHTML = '<p class="empty-message">No saved ranges yet</p>';
+      return;
     }
-    // Sort by timestamp (newest first)
     ranges.sort((a, b) => b.timestamp - a.timestamp);
-    container.innerHTML = '';
+    container.innerHTML = "";
     ranges.forEach((range) => {
-        const item = document.createElement('div');
-        item.className = 'saved-range-item';
-        const nameSpan = document.createElement('span');
-        nameSpan.className = 'saved-range-name';
-        nameSpan.textContent = range.name;
-        const handCount = Array.isArray(range.hands) ? range.hands.length : Object.keys(range.hands).length;
-        nameSpan.title = `${handCount} hands - Click to load`;
-        nameSpan.addEventListener('click', () => loadSavedRange(range.name));
-        const buttonContainer = document.createElement('div');
-        buttonContainer.className = 'range-action-buttons';
-        const copyBtn = document.createElement('button');
-        copyBtn.className = 'copy-range-btn';
-        copyBtn.innerHTML = '📋';
-        copyBtn.title = 'Copy to clipboard (presets.json format)';
-        copyBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            copyRangeToClipboard(range.name);
-        });
-        const deleteBtn = document.createElement('button');
-        deleteBtn.className = 'delete-range-btn';
-        deleteBtn.innerHTML = '×';
-        deleteBtn.title = 'Delete range';
-        deleteBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            deleteSavedRange(range.name);
-        });
-        buttonContainer.appendChild(copyBtn);
-        buttonContainer.appendChild(deleteBtn);
-        item.appendChild(nameSpan);
-        item.appendChild(buttonContainer);
-        container.appendChild(item);
+      const item = document.createElement("div");
+      item.className = "saved-range-item";
+      const nameSpan = document.createElement("span");
+      nameSpan.className = "saved-range-name";
+      nameSpan.textContent = range.name;
+      const handCount = Array.isArray(range.hands) ? range.hands.length : Object.keys(range.hands).length;
+      nameSpan.title = `${handCount} hands - Click to load`;
+      nameSpan.addEventListener("click", () => loadSavedRange(range.name));
+      const buttonContainer = document.createElement("div");
+      buttonContainer.className = "range-action-buttons";
+      const copyBtn = document.createElement("button");
+      copyBtn.className = "copy-range-btn";
+      copyBtn.innerHTML = "\u{1F4CB}";
+      copyBtn.title = "Copy to clipboard (presets.json format)";
+      copyBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        copyRangeToClipboard(range.name);
+      });
+      const deleteBtn = document.createElement("button");
+      deleteBtn.className = "delete-range-btn";
+      deleteBtn.innerHTML = "\xD7";
+      deleteBtn.title = "Delete range";
+      deleteBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        deleteSavedRange(range.name);
+      });
+      buttonContainer.appendChild(copyBtn);
+      buttonContainer.appendChild(deleteBtn);
+      item.appendChild(nameSpan);
+      item.appendChild(buttonContainer);
+      container.appendChild(item);
     });
-}
-/**
- * Switch between edit and train modes
- */
-function switchMode(mode) {
-    currentMode = mode;
-    const navBar = document.querySelector('.nav-bar');
-    const editElements = document.querySelectorAll('.edit-only');
-    const trainElements = document.querySelectorAll('.train-only');
-    const modeToggle = document.getElementById('mode-toggle');
-    if (mode === 'train') {
-        // Keep nav bar visible for mode toggle button, but hide other nav sections
-        if (navBar)
-            navBar.style.display = 'block';
-        const navSections = navBar.querySelectorAll('.nav-section');
-        navSections.forEach((section, index) => {
-            // Keep first section (mode toggle) visible, hide others
-            if (index > 0) {
-                section.style.display = 'none';
-            }
-        });
-        editElements.forEach(el => el.style.display = 'none');
-        trainElements.forEach(el => el.style.display = 'block');
-        // Store current range as training target
-        trainingRange = getCurrentSelection();
-        // Get preset info if available
-        if (currentLoadedPresetKey && loadedPresets[currentLoadedPresetKey]) {
-            const preset = loadedPresets[currentLoadedPresetKey];
-            trainingRangeName = preset.name;
-            trainingRangeDescription = preset.description;
+  }
+
+  // src/training.ts
+  function switchMode(mode) {
+    setCurrentMode(mode);
+    const navBar = document.querySelector(".nav-bar");
+    const editElements = document.querySelectorAll(".edit-only");
+    const trainElements = document.querySelectorAll(".train-only");
+    const modeToggle = document.getElementById("mode-toggle");
+    if (mode === "train") {
+      if (navBar)
+        navBar.style.display = "block";
+      const navSections = navBar.querySelectorAll(".nav-section");
+      navSections.forEach((section, index) => {
+        if (index > 0) {
+          section.style.display = "none";
         }
-        else {
-            trainingRangeName = 'Custom Range';
-            trainingRangeDescription = 'User-created range';
-        }
-        // Display range info
-        const rangeInfoDiv = document.getElementById('train-range-info');
-        if (rangeInfoDiv) {
-            rangeInfoDiv.innerHTML = `
+      });
+      editElements.forEach((el) => el.style.display = "none");
+      trainElements.forEach((el) => el.style.display = "block");
+      setTrainingRange(getCurrentSelection());
+      if (currentLoadedPresetKey && loadedPresets[currentLoadedPresetKey]) {
+        const preset = loadedPresets[currentLoadedPresetKey];
+        setTrainingRangeName(preset.name);
+        setTrainingRangeDescription(preset.description);
+      } else {
+        setTrainingRangeName("Custom Range");
+        setTrainingRangeDescription("User-created range");
+      }
+      const rangeInfoDiv = document.getElementById("train-range-info");
+      if (rangeInfoDiv) {
+        rangeInfoDiv.innerHTML = `
                 <h2>${trainingRangeName}</h2>
                 <p class="range-description">${trainingRangeDescription}</p>
             `;
-        }
-        const spotDrillRangeInfoDiv = document.getElementById('spot-drill-range-info');
-        if (spotDrillRangeInfoDiv) {
-            spotDrillRangeInfoDiv.innerHTML = `
+      }
+      const spotDrillRangeInfoDiv = document.getElementById("spot-drill-range-info");
+      if (spotDrillRangeInfoDiv) {
+        spotDrillRangeInfoDiv.innerHTML = `
                 <h2>${trainingRangeName}</h2>
                 <p class="range-description">${trainingRangeDescription}</p>
             `;
-        }
-        // Clear the grid for practice
-        resetAll();
-        // Ensure edit mode button states are synced
-        setEditMode(currentEditMode);
-        // Update training mode display
-        updateTrainingModeDisplay();
-        // Update toggle button
-        if (modeToggle)
-            modeToggle.textContent = '← Back to Edit Mode';
+      }
+      resetAll();
+      setEditMode(currentEditMode);
+      updateTrainingModeDisplay();
+      if (modeToggle)
+        modeToggle.textContent = "\u2190 Back to Edit Mode";
+    } else {
+      if (navBar)
+        navBar.style.display = "block";
+      const navSections = navBar.querySelectorAll(".nav-section");
+      navSections.forEach((section) => {
+        section.style.display = "block";
+      });
+      editElements.forEach((el) => el.style.display = "block");
+      trainElements.forEach((el) => el.style.display = "none");
+      const rangeGrid = document.getElementById("range-grid");
+      if (rangeGrid) {
+        rangeGrid.style.display = "grid";
+      }
+      if (trainingRange) {
+        loadHandsWithActions(trainingRange);
+      }
+      setTrainingRange(null);
+      setTrainingRangeName("");
+      setTrainingRangeDescription("");
+      setSpotDrillState(null);
+      setEditMode(currentEditMode);
+      if (modeToggle)
+        modeToggle.textContent = "Switch to Train Mode \u2192";
     }
-    else {
-        // Show navigation and edit elements
-        if (navBar)
-            navBar.style.display = 'block';
-        // Show all nav sections
-        const navSections = navBar.querySelectorAll('.nav-section');
-        navSections.forEach((section) => {
-            section.style.display = 'block';
-        });
-        editElements.forEach(el => el.style.display = 'block');
-        trainElements.forEach(el => el.style.display = 'none');
-        // Restore the training range to the grid
-        const rangeGrid = document.getElementById('range-grid');
-        if (rangeGrid) {
-            rangeGrid.style.display = 'grid';
-        }
-        if (trainingRange) {
-            loadHandsWithActions(trainingRange);
-        }
-        // Clear training data
-        trainingRange = null;
-        trainingRangeName = '';
-        trainingRangeDescription = '';
-        spotDrillState = null;
-        // Ensure edit mode button states are synced
-        setEditMode(currentEditMode);
-        // Update toggle button
-        if (modeToggle)
-            modeToggle.textContent = 'Switch to Train Mode →';
-    }
-}
-/**
- * Switch between training modes (Range Recall vs Spot Drill)
- */
-function switchTrainingMode(mode) {
-    currentTrainingMode = mode;
+  }
+  function switchTrainingMode(mode) {
+    setCurrentTrainingMode(mode);
     updateTrainingModeDisplay();
-    if (mode === 'spot-drill') {
-        startSpotDrill();
+    if (mode === "spot-drill") {
+      startSpotDrill();
+    } else {
+      stopSpotDrill();
     }
-    else {
-        stopSpotDrill();
+  }
+  function updateTrainingModeDisplay() {
+    const rangeRecallMode = document.querySelector(".range-recall-mode");
+    const spotDrillMode = document.querySelector(".spot-drill-mode");
+    const rangeGrid = document.getElementById("range-grid");
+    const trainControls = document.querySelector(".train-controls");
+    const trainResult = document.getElementById("train-result");
+    const spotDrillResult = document.getElementById("spot-drill-result");
+    const rangeRecallBtn = document.getElementById("range-recall-btn");
+    const spotDrillBtn = document.getElementById("spot-drill-btn");
+    if (currentTrainingMode === "spot-drill") {
+      if (rangeRecallMode)
+        rangeRecallMode.style.display = "none";
+      if (spotDrillMode)
+        spotDrillMode.style.display = "block";
+      if (rangeGrid)
+        rangeGrid.style.display = "none";
+      if (trainControls)
+        trainControls.style.display = "none";
+      if (trainResult)
+        trainResult.style.display = "none";
+      if (rangeRecallBtn)
+        rangeRecallBtn.classList.remove("active");
+      if (spotDrillBtn)
+        spotDrillBtn.classList.add("active");
+    } else {
+      if (rangeRecallMode)
+        rangeRecallMode.style.display = "block";
+      if (spotDrillMode)
+        spotDrillMode.style.display = "none";
+      if (rangeGrid)
+        rangeGrid.style.display = "grid";
+      if (trainControls)
+        trainControls.style.display = "flex";
+      if (spotDrillResult)
+        spotDrillResult.style.display = "none";
+      if (rangeRecallBtn)
+        rangeRecallBtn.classList.add("active");
+      if (spotDrillBtn)
+        spotDrillBtn.classList.remove("active");
     }
-}
-/**
- * Update the display based on current training mode
- */
-function updateTrainingModeDisplay() {
-    const rangeRecallMode = document.querySelector('.range-recall-mode');
-    const spotDrillMode = document.querySelector('.spot-drill-mode');
-    const rangeGrid = document.getElementById('range-grid');
-    const trainControls = document.querySelector('.train-controls');
-    const trainResult = document.getElementById('train-result');
-    const spotDrillResult = document.getElementById('spot-drill-result');
-    const rangeRecallBtn = document.getElementById('range-recall-btn');
-    const spotDrillBtn = document.getElementById('spot-drill-btn');
-    if (currentTrainingMode === 'spot-drill') {
-        if (rangeRecallMode)
-            rangeRecallMode.style.display = 'none';
-        if (spotDrillMode)
-            spotDrillMode.style.display = 'block';
-        if (rangeGrid)
-            rangeGrid.style.display = 'none';
-        if (trainControls)
-            trainControls.style.display = 'none';
-        if (trainResult)
-            trainResult.style.display = 'none';
-        if (rangeRecallBtn)
-            rangeRecallBtn.classList.remove('active');
-        if (spotDrillBtn)
-            spotDrillBtn.classList.add('active');
-    }
-    else {
-        if (rangeRecallMode)
-            rangeRecallMode.style.display = 'block';
-        if (spotDrillMode)
-            spotDrillMode.style.display = 'none';
-        if (rangeGrid)
-            rangeGrid.style.display = 'grid';
-        if (trainControls)
-            trainControls.style.display = 'flex';
-        if (spotDrillResult)
-            spotDrillResult.style.display = 'none';
-        if (rangeRecallBtn)
-            rangeRecallBtn.classList.add('active');
-        if (spotDrillBtn)
-            spotDrillBtn.classList.remove('active');
-    }
-}
-/**
- * Generate a shuffled array of hands from the training range
- */
-function generateHandsQueue(count, excludeHands) {
+  }
+  function generateHandsQueue(count, excludeHands) {
     if (!trainingRange)
-        return [];
+      return [];
     let hands = Object.keys(trainingRange);
-    // Exclude hands that have already been shown
     if (excludeHands && excludeHands.length > 0) {
-        const excludeSet = new Set(excludeHands);
-        hands = hands.filter(hand => !excludeSet.has(hand));
+      const excludeSet = new Set(excludeHands);
+      hands = hands.filter((hand) => !excludeSet.has(hand));
     }
-    // If we've exhausted all hands, shuffle and start over
     if (hands.length === 0) {
-        hands = Object.keys(trainingRange);
+      hands = Object.keys(trainingRange);
     }
     const shuffled = [...hands].sort(() => Math.random() - 0.5);
     return shuffled.slice(0, Math.min(count, shuffled.length));
-}
-/**
- * Start a new Spot Drill session
- */
-function startSpotDrill() {
+  }
+  function startSpotDrill() {
     if (!trainingRange)
-        return;
+      return;
     const initialHands = generateHandsQueue(INITIAL_HANDS_COUNT);
-    spotDrillState = {
-        handsQueue: initialHands,
-        currentHandIndex: 0,
-        correctAnswers: 0,
-        totalAttempts: 0,
-        results: []
-    };
-    // Show first hand
+    setSpotDrillState({
+      handsQueue: initialHands,
+      currentHandIndex: 0,
+      correctAnswers: 0,
+      totalAttempts: 0,
+      results: []
+    });
     displayNextHand();
     updateSpotDrillProgress();
-    // Hide results if showing
-    const resultDiv = document.getElementById('spot-drill-result');
+    const resultDiv = document.getElementById("spot-drill-result");
     if (resultDiv)
-        resultDiv.style.display = 'none';
-}
-/**
- * Stop Spot Drill and reset state
- */
-function stopSpotDrill() {
-    spotDrillState = null;
-}
-/**
- * Parse a hand notation string to extract card ranks
- * Examples: "QJs" -> ["Q", "J"], "AA" -> ["A", "A"], "KQo" -> ["K", "Q"]
- */
-function parseHand(hand) {
-    // Remove trailing 's' (suited) or 'o' (offsuit) if present
-    const cleanHand = hand.replace(/[so]$/, '');
-    const suited = hand.endsWith('s');
+      resultDiv.style.display = "none";
+  }
+  function stopSpotDrill() {
+    setSpotDrillState(null);
+  }
+  function parseHand(hand) {
+    const cleanHand = hand.replace(/[so]$/, "");
+    const suited = hand.endsWith("s");
     if (cleanHand.length === 2) {
-        // Pocket pair or two different ranks
-        return {
-            rank1: cleanHand[0],
-            rank2: cleanHand[1],
-            suited
-        };
+      return {
+        rank1: cleanHand[0],
+        rank2: cleanHand[1],
+        suited
+      };
     }
-    // Fallback for unexpected formats
-    return { rank1: '?', rank2: '?', suited: false };
-}
-/**
- * Get color for a card based on rank (for visualization)
- * Uses only four colors: red, green, blue, and black
- */
-function getCardColor(rank, index, suited) {
-    // Only four colors: red, green, blue, black
-    // Assign colors based on rank for consistency
+    return { rank1: "?", rank2: "?", suited: false };
+  }
+  function getCardColor(rank, index, suited) {
     const rankColors = {
-        'A': '#dc3545', // Red
-        'K': '#000000', // Black
-        'Q': '#007bff', // Blue
-        'J': '#28a745', // Green
-        'T': '#dc3545', // Red
-        '9': '#28a745', // Green
-        '8': '#007bff', // Blue
-        '7': '#000000', // Black
-        '6': '#dc3545', // Red
-        '5': '#28a745', // Green
-        '4': '#007bff', // Blue
-        '3': '#000000', // Black
-        '2': '#dc3545', // Red
+      "A": "#dc3545",
+      // Red
+      "K": "#000000",
+      // Black
+      "Q": "#007bff",
+      // Blue
+      "J": "#28a745",
+      // Green
+      "T": "#dc3545",
+      // Red
+      "9": "#28a745",
+      // Green
+      "8": "#007bff",
+      // Blue
+      "7": "#000000",
+      // Black
+      "6": "#dc3545",
+      // Red
+      "5": "#28a745",
+      // Green
+      "4": "#007bff",
+      // Blue
+      "3": "#000000",
+      // Black
+      "2": "#dc3545"
+      // Red
     };
-    // Use rank-based color, or fallback to index-based
     if (rankColors[rank]) {
-        return rankColors[rank];
+      return rankColors[rank];
     }
-    // Fallback: index-based coloring with four colors only
     if (index === 0) {
-        return '#dc3545'; // Red
+      return "#dc3545";
+    } else {
+      if (suited) {
+        return "#28a745";
+      } else {
+        return "#007bff";
+      }
     }
-    else {
-        if (suited) {
-            return '#28a745'; // Green for suited
-        }
-        else {
-            return '#007bff'; // Blue for offsuit
-        }
-    }
-}
-/**
- * Create a card element as a colored square with letter
- */
-function createCardElement(rank, color) {
-    const card = document.createElement('div');
-    card.className = 'card-square';
+  }
+  function createCardElement(rank, color) {
+    const card = document.createElement("div");
+    card.className = "card-square";
     card.textContent = rank;
     card.style.backgroundColor = color;
     return card;
-}
-/**
- * Display the next hand in the queue with visual card representation
- */
-function displayNextHand() {
+  }
+  function displayNextHand() {
     if (!spotDrillState || spotDrillState.currentHandIndex >= spotDrillState.handsQueue.length) {
-        // All hands shown, show results
-        showSpotDrillResults();
-        return;
+      showSpotDrillResults();
+      return;
     }
     const currentHand = spotDrillState.handsQueue[spotDrillState.currentHandIndex];
     const { rank1, rank2, suited } = parseHand(currentHand);
-    // Display in table center only
-    const handDisplay = document.getElementById('current-hand-display');
+    const handDisplay = document.getElementById("current-hand-display");
     if (handDisplay) {
-        handDisplay.innerHTML = '';
-        // Create card elements
-        const card1 = createCardElement(rank1, getCardColor(rank1, 0, suited));
-        const card2 = createCardElement(rank2, getCardColor(rank2, 1, suited));
-        handDisplay.appendChild(card1);
-        handDisplay.appendChild(card2);
+      handDisplay.innerHTML = "";
+      const card1 = createCardElement(rank1, getCardColor(rank1, 0, suited));
+      const card2 = createCardElement(rank2, getCardColor(rank2, 1, suited));
+      handDisplay.appendChild(card1);
+      handDisplay.appendChild(card2);
     }
-}
-/**
- * Handle action selection in Spot Drill
- */
-function handleSpotDrillAction(action) {
+  }
+  function handleSpotDrillAction(action) {
     if (!spotDrillState || !trainingRange)
-        return;
+      return;
     const currentHand = spotDrillState.handsQueue[spotDrillState.currentHandIndex];
     const correctAction = trainingRange[currentHand];
     const isCorrect = action === correctAction;
-    // Record result
     spotDrillState.results.push({
-        hand: currentHand,
-        correctAction: correctAction,
-        userAction: action,
-        correct: isCorrect
+      hand: currentHand,
+      correctAction,
+      userAction: action,
+      correct: isCorrect
     });
     if (isCorrect) {
-        spotDrillState.correctAnswers++;
-        showToast('✓ Correct!', 'success');
-    }
-    else {
-        showToast(`✗ Wrong! Correct action: ${correctAction.charAt(0).toUpperCase() + correctAction.slice(1)}`, 'error');
+      spotDrillState.correctAnswers++;
+      showToast("\u2713 Correct!", "success");
+    } else {
+      showToast(`\u2717 Wrong! Correct action: ${correctAction.charAt(0).toUpperCase() + correctAction.slice(1)}`, "error");
     }
     spotDrillState.totalAttempts++;
     spotDrillState.currentHandIndex++;
     updateSpotDrillProgress();
-    // Show next hand after a brief delay
     setTimeout(() => {
-        displayNextHand();
-    }, 1000);
-}
-/**
- * Update progress display
- */
-function updateSpotDrillProgress() {
+      displayNextHand();
+    }, 1e3);
+  }
+  function updateSpotDrillProgress() {
     if (!spotDrillState)
-        return;
-    const progressText = document.getElementById('spot-drill-progress-text');
+      return;
+    const progressText = document.getElementById("spot-drill-progress-text");
     if (progressText) {
-        const completed = spotDrillState.currentHandIndex;
-        const total = spotDrillState.handsQueue.length;
-        progressText.textContent = `${completed} / ${total}`;
+      const completed = spotDrillState.currentHandIndex;
+      const total = spotDrillState.handsQueue.length;
+      progressText.textContent = `${completed} / ${total}`;
     }
-}
-/**
- * Show Spot Drill results
- */
-function showSpotDrillResults() {
+  }
+  function showSpotDrillResults() {
     var _a, _b;
     if (!spotDrillState)
-        return;
-    const resultDiv = document.getElementById('spot-drill-result');
+      return;
+    const resultDiv = document.getElementById("spot-drill-result");
     if (!resultDiv)
-        return;
-    const accuracy = spotDrillState.totalAttempts > 0
-        ? ((spotDrillState.correctAnswers / spotDrillState.totalAttempts) * 100).toFixed(1)
-        : '0.0';
+      return;
+    const accuracy = spotDrillState.totalAttempts > 0 ? (spotDrillState.correctAnswers / spotDrillState.totalAttempts * 100).toFixed(1) : "0.0";
     const resultsHtml = `
         <h3>Spot Drill Results</h3>
         <p class="accuracy">Accuracy: ${accuracy}%</p>
-        <p>✓ Correct: ${spotDrillState.correctAnswers} / ${spotDrillState.totalAttempts}</p>
+        <p>\u2713 Correct: ${spotDrillState.correctAnswers} / ${spotDrillState.totalAttempts}</p>
         <div class="spot-drill-results-actions">
             <button id="continue-drill-btn" class="train-button submit-button">Continue Drilling</button>
             <button id="restart-drill-btn" class="train-button reset-button">Restart</button>
         </div>
     `;
     resultDiv.innerHTML = resultsHtml;
-    resultDiv.style.display = 'block';
-    // Setup continue and restart buttons
-    const continueBtn = document.getElementById('continue-drill-btn');
-    const restartBtn = document.getElementById('restart-drill-btn');
+    resultDiv.style.display = "block";
+    const continueBtn = document.getElementById("continue-drill-btn");
+    const restartBtn = document.getElementById("restart-drill-btn");
     if (continueBtn) {
-        // Remove old event listener by cloning and replacing
-        const newContinueBtn = continueBtn.cloneNode(true);
-        (_a = continueBtn.parentNode) === null || _a === void 0 ? void 0 : _a.replaceChild(newContinueBtn, continueBtn);
-        newContinueBtn.addEventListener('click', () => {
-            // Add more hands to queue, excluding already shown hands
-            if (spotDrillState) {
-                const shownHands = spotDrillState.results.map(r => r.hand);
-                const additionalHands = generateHandsQueue(INITIAL_HANDS_COUNT, shownHands);
-                if (additionalHands.length > 0) {
-                    spotDrillState.handsQueue = [...spotDrillState.handsQueue, ...additionalHands];
-                    resultDiv.style.display = 'none';
-                    displayNextHand();
-                }
-                else {
-                    // All hands have been shown, show final results
-                    showSpotDrillResults();
-                }
-            }
-        });
+      const newContinueBtn = continueBtn.cloneNode(true);
+      (_a = continueBtn.parentNode) == null ? void 0 : _a.replaceChild(newContinueBtn, continueBtn);
+      newContinueBtn.addEventListener("click", () => {
+        if (spotDrillState) {
+          const shownHands = spotDrillState.results.map((r) => r.hand);
+          const additionalHands = generateHandsQueue(INITIAL_HANDS_COUNT, shownHands);
+          if (additionalHands.length > 0) {
+            spotDrillState.handsQueue = [...spotDrillState.handsQueue, ...additionalHands];
+            resultDiv.style.display = "none";
+            displayNextHand();
+          } else {
+            showSpotDrillResults();
+          }
+        }
+      });
     }
     if (restartBtn) {
-        // Remove old event listener by cloning and replacing
-        const newRestartBtn = restartBtn.cloneNode(true);
-        (_b = restartBtn.parentNode) === null || _b === void 0 ? void 0 : _b.replaceChild(newRestartBtn, restartBtn);
-        newRestartBtn.addEventListener('click', () => {
-            startSpotDrill();
-        });
+      const newRestartBtn = restartBtn.cloneNode(true);
+      (_b = restartBtn.parentNode) == null ? void 0 : _b.replaceChild(newRestartBtn, restartBtn);
+      newRestartBtn.addEventListener("click", () => {
+        startSpotDrill();
+      });
     }
-}
-/**
- * Show a toast notification
- */
-function showToast(message, type) {
-    const container = document.getElementById('toast-container');
-    if (!container)
-        return;
-    const toast = document.createElement('div');
-    toast.className = `toast toast-${type}`;
-    toast.textContent = message;
-    container.appendChild(toast);
-    // Trigger animation
-    setTimeout(() => {
-        toast.classList.add('show');
-    }, 10);
-    // Remove after animation
-    setTimeout(() => {
-        toast.classList.remove('show');
-        setTimeout(() => {
-            container.removeChild(toast);
-        }, 300);
-    }, 2000);
-}
-/**
- * Show a confirmation dialog using a modal
- * Returns a Promise that resolves to true if confirmed, false if cancelled
- */
-function showConfirm(message) {
-    return new Promise((resolve) => {
-        // Create modal overlay
-        const overlay = document.createElement('div');
-        overlay.className = 'confirm-modal-overlay';
-        // Create modal
-        const modal = document.createElement('div');
-        modal.className = 'confirm-modal';
-        // Create message
-        const messageDiv = document.createElement('div');
-        messageDiv.className = 'confirm-message';
-        messageDiv.textContent = message;
-        // Create buttons container
-        const buttonsDiv = document.createElement('div');
-        buttonsDiv.className = 'confirm-buttons';
-        // Create confirm button
-        const confirmBtn = document.createElement('button');
-        confirmBtn.className = 'confirm-btn confirm-btn-ok';
-        confirmBtn.textContent = 'OK';
-        confirmBtn.addEventListener('click', () => {
-            document.body.removeChild(overlay);
-            resolve(true);
-        });
-        // Create cancel button
-        const cancelBtn = document.createElement('button');
-        cancelBtn.className = 'confirm-btn confirm-btn-cancel';
-        cancelBtn.textContent = 'Cancel';
-        cancelBtn.addEventListener('click', () => {
-            document.body.removeChild(overlay);
-            resolve(false);
-        });
-        // Assemble modal
-        buttonsDiv.appendChild(confirmBtn);
-        buttonsDiv.appendChild(cancelBtn);
-        modal.appendChild(messageDiv);
-        modal.appendChild(buttonsDiv);
-        overlay.appendChild(modal);
-        // Add to DOM
-        document.body.appendChild(overlay);
-        // Trigger animation
-        setTimeout(() => {
-            overlay.classList.add('show');
-        }, 10);
-        // Handle escape key
-        const handleEscape = (e) => {
-            if (e.key === 'Escape') {
-                document.body.removeChild(overlay);
-                document.removeEventListener('keydown', handleEscape);
-                resolve(false);
-            }
-        };
-        document.addEventListener('keydown', handleEscape);
-    });
-}
-/**
- * Submit training attempt and show results
- */
-function submitTraining() {
+  }
+  function submitTraining() {
     if (!trainingRange)
-        return;
+      return;
     const userAttempt = getCurrentSelection();
     let correct = 0;
     let incorrect = 0;
     let missed = 0;
     const totalHands = Object.keys(trainingRange).length;
-    // Clear all visual states first
     handsState.forEach((handState) => {
-        const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
-        if (cell) {
-            cell.classList.remove('train-correct', 'train-incorrect', 'train-missed');
-        }
+      const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
+      if (cell) {
+        cell.classList.remove("train-correct", "train-incorrect", "train-missed");
+      }
     });
-    // Check each hand in the training range
     Object.keys(trainingRange).forEach((hand) => {
-        const correctAction = trainingRange[hand];
-        const userAction = userAttempt[hand];
-        const cell = document.querySelector(`[data-hand="${hand}"]`);
-        if (userAction === correctAction) {
-            // Correct
-            correct++;
-            if (cell)
-                cell.classList.add('train-correct');
-        }
-        else if (userAction && userAction !== correctAction) {
-            // Wrong action
-            incorrect++;
-            if (cell)
-                cell.classList.add('train-incorrect');
-        }
-        else {
-            // Missed
-            missed++;
-            if (cell)
-                cell.classList.add('train-missed');
-        }
+      const correctAction = trainingRange[hand];
+      const userAction = userAttempt[hand];
+      const cell = document.querySelector(`[data-hand="${hand}"]`);
+      if (userAction === correctAction) {
+        correct++;
+        if (cell)
+          cell.classList.add("train-correct");
+      } else if (userAction && userAction !== correctAction) {
+        incorrect++;
+        if (cell)
+          cell.classList.add("train-incorrect");
+      } else {
+        missed++;
+        if (cell)
+          cell.classList.add("train-missed");
+      }
     });
-    // Check for extra hands user added that shouldn't be there
     Object.keys(userAttempt).forEach((hand) => {
-        if (!trainingRange[hand]) {
-            incorrect++;
-            const cell = document.querySelector(`[data-hand="${hand}"]`);
-            if (cell)
-                cell.classList.add('train-incorrect');
-        }
+      if (!trainingRange[hand]) {
+        incorrect++;
+        const cell = document.querySelector(`[data-hand="${hand}"]`);
+        if (cell)
+          cell.classList.add("train-incorrect");
+      }
     });
-    // Calculate accuracy
-    const accuracy = totalHands > 0 ? ((correct / totalHands) * 100).toFixed(1) : '0.0';
-    // Show results
-    const resultDiv = document.getElementById('train-result');
+    const accuracy = totalHands > 0 ? (correct / totalHands * 100).toFixed(1) : "0.0";
+    const resultDiv = document.getElementById("train-result");
     if (resultDiv) {
-        resultDiv.innerHTML = `
+      resultDiv.innerHTML = `
             <h3>Results</h3>
             <p class="accuracy">Accuracy: ${accuracy}%</p>
-            <p>✓ Correct: ${correct} / ${totalHands}</p>
-            <p>✗ Incorrect: ${incorrect}</p>
-            <p>⊗ Missed: ${missed}</p>
+            <p>\u2713 Correct: ${correct} / ${totalHands}</p>
+            <p>\u2717 Incorrect: ${incorrect}</p>
+            <p>\u2297 Missed: ${missed}</p>
             <p class="result-legend">Green border = Correct | Red border = Incorrect | Yellow border = Missed</p>
         `;
-        resultDiv.style.display = 'block';
-        resultDiv.classList.remove('pulse-animation');
-        // Trigger reflow to restart animation
-        void resultDiv.offsetWidth;
-        resultDiv.classList.add('pulse-animation');
+      resultDiv.style.display = "block";
+      resultDiv.classList.remove("pulse-animation");
+      void resultDiv.offsetWidth;
+      resultDiv.classList.add("pulse-animation");
     }
-}
-/**
- * Reset training attempt
- */
-function resetTraining() {
+  }
+  function resetTraining() {
     resetAll();
-    // Clear result display
-    const resultDiv = document.getElementById('train-result');
+    const resultDiv = document.getElementById("train-result");
     if (resultDiv) {
-        resultDiv.style.display = 'none';
+      resultDiv.style.display = "none";
     }
-    // Clear training visual states
     handsState.forEach((handState) => {
-        const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
-        if (cell) {
-            cell.classList.remove('train-correct', 'train-incorrect', 'train-missed');
-        }
+      const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
+      if (cell) {
+        cell.classList.remove("train-correct", "train-incorrect", "train-missed");
+      }
     });
-}
-/**
- * Setup mobile navigation toggle
- */
-function setupMobileNavigation() {
-    const mobileNavToggle = document.getElementById('mobile-nav-toggle');
-    const navBar = document.getElementById('nav-bar');
-    const navBackdrop = document.getElementById('nav-backdrop');
-    const hamburgerIcon = mobileNavToggle === null || mobileNavToggle === void 0 ? void 0 : mobileNavToggle.querySelector('.hamburger-icon');
-    const closeIcon = mobileNavToggle === null || mobileNavToggle === void 0 ? void 0 : mobileNavToggle.querySelector('.close-icon');
-    if (!mobileNavToggle || !navBar || !navBackdrop)
-        return;
-    function openNav() {
-        navBar.classList.add('mobile-open');
-        navBackdrop.classList.add('show');
-        if (hamburgerIcon)
-            hamburgerIcon.style.display = 'none';
-        if (closeIcon)
-            closeIcon.style.display = 'block';
-        // Prevent body scroll when nav is open
-        document.body.style.overflow = 'hidden';
-    }
-    function closeNav() {
-        navBar.classList.remove('mobile-open');
-        navBackdrop.classList.remove('show');
-        if (hamburgerIcon)
-            hamburgerIcon.style.display = 'block';
-        if (closeIcon)
-            closeIcon.style.display = 'none';
-        // Restore body scroll
-        document.body.style.overflow = '';
-    }
-    // Toggle nav on button click
-    mobileNavToggle.addEventListener('click', () => {
-        if (navBar.classList.contains('mobile-open')) {
-            closeNav();
-        }
-        else {
-            openNav();
-        }
-    });
-    // Close nav on backdrop click
-    navBackdrop.addEventListener('click', () => {
-        closeNav();
-    });
-    // Close nav when clicking a nav button (optional - for better UX)
-    const navButtons = navBar.querySelectorAll('.nav-button, .preset-button, .mode-toggle-btn');
-    navButtons.forEach(button => {
-        button.addEventListener('click', () => {
-            // Small delay to allow the action to complete
-            setTimeout(() => {
-                closeNav();
-            }, 300);
-        });
-    });
-    // Close nav on window resize (if resizing to desktop)
-    window.addEventListener('resize', () => {
-        if (window.innerWidth > 768) {
-            closeNav();
-        }
-    });
-}
-/**
- * Setup navigation button event listeners
- */
-function setupNavigation() {
-    // Edit mode buttons
-    const editModeButtons = document.querySelectorAll('.edit-mode-btn');
+  }
+
+  // src/app.ts
+  function setupNavigation() {
+    const editModeButtons = document.querySelectorAll(".edit-mode-btn");
     editModeButtons.forEach((button) => {
-        button.addEventListener('click', (e) => {
-            const target = e.target;
-            const action = target.dataset.action;
-            if (action) {
-                setEditMode(action);
-            }
-        });
+      button.addEventListener("click", (e) => {
+        const target = e.target;
+        const action = target.dataset.action;
+        if (action) {
+          setEditMode(action);
+        }
+      });
     });
-    // Initialize edit mode to 'raise' by default
-    setEditMode('raise');
-    // Reset button
-    const resetBtn = document.getElementById('reset-btn');
+    setEditMode("raise");
+    const resetBtn = document.getElementById("reset-btn");
     if (resetBtn) {
-        resetBtn.addEventListener('click', resetAll);
+      resetBtn.addEventListener("click", resetAll);
     }
-    // Select all button
-    const selectAllBtn = document.getElementById('select-all-btn');
+    const selectAllBtn = document.getElementById("select-all-btn");
     if (selectAllBtn) {
-        selectAllBtn.addEventListener('click', selectAll);
+      selectAllBtn.addEventListener("click", selectAll);
     }
-    // Save range button
-    const saveRangeBtn = document.getElementById('save-range-btn');
-    const rangeNameInput = document.getElementById('range-name-input');
+    const saveRangeBtn = document.getElementById("save-range-btn");
+    const rangeNameInput = document.getElementById("range-name-input");
     if (saveRangeBtn && rangeNameInput) {
-        saveRangeBtn.addEventListener('click', () => {
-            saveCurrentRange(rangeNameInput.value);
-        });
-        // Allow Enter key to save
-        rangeNameInput.addEventListener('keypress', (e) => {
-            if (e.key === 'Enter') {
-                saveCurrentRange(rangeNameInput.value);
-            }
-        });
+      saveRangeBtn.addEventListener("click", () => {
+        saveCurrentRange(rangeNameInput.value);
+      });
+      rangeNameInput.addEventListener("keypress", (e) => {
+        if (e.key === "Enter") {
+          saveCurrentRange(rangeNameInput.value);
+        }
+      });
     }
-    // Set up event delegation for preset buttons (works with dynamically created buttons)
-    const presetsContainer = document.getElementById('presets-container');
+    const presetsContainer = document.getElementById("presets-container");
     if (presetsContainer) {
-        presetsContainer.addEventListener('click', (e) => {
-            const target = e.target;
-            if (target.classList.contains('preset-button')) {
-                const presetName = target.dataset.preset;
-                if (presetName) {
-                    loadPreset(presetName);
-                }
-            }
-        });
+      presetsContainer.addEventListener("click", (e) => {
+        const target = e.target;
+        if (target.classList.contains("preset-button")) {
+          const presetName = target.dataset.preset;
+          if (presetName) {
+            loadPreset(presetName);
+          }
+        }
+      });
     }
-    // Render saved ranges on load
     renderSavedRanges();
-    // Mode toggle button
-    const modeToggle = document.getElementById('mode-toggle');
+    const modeToggle = document.getElementById("mode-toggle");
     if (modeToggle) {
-        modeToggle.addEventListener('click', () => {
-            if (currentMode === 'edit') {
-                if (Object.keys(getCurrentSelection()).length === 0) {
-                    showToast('Please select or load a range first before entering train mode.', 'error');
-                    return;
-                }
-                switchMode('train');
-            }
-            else {
-                switchMode('edit');
-            }
-        });
+      modeToggle.addEventListener("click", () => {
+        if (currentMode === "edit") {
+          if (Object.keys(getCurrentSelection()).length === 0) {
+            showToast("Please select or load a range first before entering train mode.", "error");
+            return;
+          }
+          switchMode("train");
+        } else {
+          switchMode("edit");
+        }
+      });
     }
-    // Train mode buttons
-    const resetTrainBtn = document.getElementById('reset-train-btn');
+    const resetTrainBtn = document.getElementById("reset-train-btn");
     if (resetTrainBtn) {
-        resetTrainBtn.addEventListener('click', resetTraining);
+      resetTrainBtn.addEventListener("click", resetTraining);
     }
-    const submitTrainBtn = document.getElementById('submit-train-btn');
+    const submitTrainBtn = document.getElementById("submit-train-btn");
     if (submitTrainBtn) {
-        submitTrainBtn.addEventListener('click', submitTraining);
+      submitTrainBtn.addEventListener("click", submitTraining);
     }
-    // Training mode selector buttons
-    const rangeRecallBtn = document.getElementById('range-recall-btn');
+    const rangeRecallBtn = document.getElementById("range-recall-btn");
     if (rangeRecallBtn) {
-        rangeRecallBtn.addEventListener('click', () => {
-            switchTrainingMode('range-recall');
-        });
+      rangeRecallBtn.addEventListener("click", () => {
+        switchTrainingMode("range-recall");
+      });
     }
-    const spotDrillBtn = document.getElementById('spot-drill-btn');
+    const spotDrillBtn = document.getElementById("spot-drill-btn");
     if (spotDrillBtn) {
-        spotDrillBtn.addEventListener('click', () => {
-            switchTrainingMode('spot-drill');
-        });
+      spotDrillBtn.addEventListener("click", () => {
+        switchTrainingMode("spot-drill");
+      });
     }
-    // Spot drill action buttons
-    const spotActionButtons = document.querySelectorAll('.spot-action-btn');
+    const spotActionButtons = document.querySelectorAll(".spot-action-btn");
     spotActionButtons.forEach((button) => {
-        button.addEventListener('click', (e) => {
-            const target = e.target;
-            const action = target.dataset.action;
-            if (action) {
-                handleSpotDrillAction(action);
-            }
-        });
+      button.addEventListener("click", (e) => {
+        const target = e.target;
+        const action = target.dataset.action;
+        if (action) {
+          handleSpotDrillAction(action);
+        }
+      });
     });
-}
-/**
- * Initialize the app
- */
-function init() {
-    return __awaiter(this, void 0, void 0, function* () {
-        // Load presets from JSON file
-        yield loadPresetsFromFile();
-        createRangeGrid();
-        setupNavigation();
-        setupMobileNavigation();
-        updateStats();
-        // Add global mouse up listener to end drag
-        document.addEventListener('mouseup', () => {
-            isDragging = false;
-            dragAction = null;
-        });
-        // Add global touch end listener to end drag
-        document.addEventListener('touchend', () => {
-            handleTouchEnd();
-        });
-        // Add global touch cancel listener
-        document.addEventListener('touchcancel', () => {
-            handleTouchEnd();
-        });
-        // Prevent text selection during drag
-        document.addEventListener('selectstart', (e) => {
-            if (isDragging) {
-                e.preventDefault();
-            }
-        });
+  }
+  function init() {
+    return __async(this, null, function* () {
+      yield loadPresetsFromFile();
+      createRangeGrid();
+      setupNavigation();
+      setupMobileNavigation();
+      updateStats();
+      document.addEventListener("mouseup", () => {
+        setIsDragging(false);
+        setDragAction(null);
+      });
+      document.addEventListener("touchend", () => {
+        handleTouchEnd();
+      });
+      document.addEventListener("touchcancel", () => {
+        handleTouchEnd();
+      });
+      document.addEventListener("selectstart", (e) => {
+        if (isDragging) {
+          e.preventDefault();
+        }
+      });
     });
-}
-// Start the app when DOM is ready
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-}
-else {
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
     init();
-}
+  }
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,461 @@
+{
+  "name": "poker-range-trainer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "poker-range-trainer",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "esbuild": "^0.20.0",
+        "typescript": "^5.3.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A simple Texas Hold'em range selection tool for practicing and visualizing poker starting hand ranges",
   "main": "app.js",
   "scripts": {
-    "watch": "tsc --watch --target ES6 --lib ES2015,DOM --strict app.ts",
-    "build": "tsc --target ES6 --lib ES2015,DOM --strict app.ts",
+    "build": "esbuild src/app.ts --bundle --outfile=app.js --format=iife --target=es2015",
+    "watch": "esbuild src/app.ts --bundle --outfile=app.js --format=iife --target=es2015 --watch",
     "dev": "docker compose up",
     "dev-build": "docker compose up --build",
     "down": "docker compose down",
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "esbuild": "^0.20.0",
     "typescript": "^5.3.0"
   }
 }
-

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,109 @@
+import { HandAction } from './types';
+import { handsState, currentEditMode, setCurrentEditMode } from './state';
+
+/**
+ * Set action state of a hand
+ */
+export function setHandAction(hand: string, action: HandAction): void {
+    const handState = handsState.get(hand);
+    if (!handState) return;
+    
+    // Only update if state is changing
+    if (handState.action === action) return;
+    
+    handState.action = action;
+    
+    // Update UI
+    const cell = document.querySelector(`[data-hand="${hand}"]`);
+    if (cell) {
+        // Remove all action classes
+        cell.classList.remove('action-fold', 'action-raise', 'action-call', 'action-mix-rc', 'action-mix-rf');
+        
+        // Add appropriate class
+        cell.classList.add(`action-${action}`);
+    }
+    
+    // Update stats
+    updateStats();
+}
+
+/**
+ * Set the current edit mode
+ */
+export function setEditMode(action: HandAction): void {
+    setCurrentEditMode(action);
+    
+    // Update button states
+    const buttons = document.querySelectorAll('.edit-mode-btn');
+    buttons.forEach((btn) => {
+        const button = btn as HTMLButtonElement;
+        if (button.dataset.action === action) {
+            button.classList.add('active');
+        } else {
+            button.classList.remove('active');
+        }
+    });
+}
+
+/**
+ * Update the selection statistics display
+ */
+export function updateStats(): void {
+    const raiseCount = Array.from(handsState.values()).filter(h => h.action === 'raise').length;
+    const callCount = Array.from(handsState.values()).filter(h => h.action === 'call').length;
+    const mixRcCount = Array.from(handsState.values()).filter(h => h.action === 'mix-rc').length;
+    const mixRfCount = Array.from(handsState.values()).filter(h => h.action === 'mix-rf').length;
+    const totalSelected = raiseCount + callCount + mixRcCount + mixRfCount;
+    const totalHands = 169;
+    const percentage = ((totalSelected / totalHands) * 100).toFixed(1);
+    const raisePercentage = ((raiseCount / totalHands) * 100).toFixed(1);
+    const callPercentage = ((callCount / totalHands) * 100).toFixed(1);
+    const mixRcPercentage = ((mixRcCount / totalHands) * 100).toFixed(1);
+    const mixRfPercentage = ((mixRfCount / totalHands) * 100).toFixed(1);
+    
+    const countElement = document.getElementById('selected-count');
+    if (countElement) {
+        countElement.textContent = `${percentage}% (Raise: ${raisePercentage}%, Call: ${callPercentage}%, Mix RC: ${mixRcPercentage}%, Mix RF: ${mixRfPercentage}%) - ${totalSelected} / ${totalHands}`;
+    }
+}
+
+/**
+ * Reset all hands to fold state
+ */
+export function resetAll(): void {
+    handsState.forEach((handState) => {
+        if (handState.action !== 'fold') {
+            setHandAction(handState.hand, 'fold');
+        }
+        
+        // Clear any training feedback classes
+        const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
+        if (cell) {
+            cell.classList.remove('train-correct', 'train-incorrect', 'train-missed');
+        }
+    });
+}
+
+/**
+ * Select all hands as raise
+ */
+export function selectAll(): void {
+    handsState.forEach((handState) => {
+        if (handState.action !== 'raise') {
+            setHandAction(handState.hand, 'raise');
+        }
+    });
+}
+
+/**
+ * Get currently selected hands with their actions
+ */
+export function getCurrentSelection(): { [hand: string]: HandAction } {
+    const selected: { [hand: string]: HandAction } = {};
+    handsState.forEach((handState) => {
+        if (handState.action !== 'fold') {
+            selected[handState.hand] = handState.action;
+        }
+    });
+    return selected;
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,174 @@
+import { HandAction } from './types';
+import {
+    isDragging, currentMode,
+    setIsDragging, setDragAction
+} from './state';
+import { setEditMode, resetAll, selectAll, getCurrentSelection, updateStats } from './actions';
+import { createRangeGrid, handleTouchEnd } from './grid';
+import { loadPresetsFromFile, loadPreset } from './presets';
+import { saveCurrentRange, renderSavedRanges } from './storage';
+import { switchMode, switchTrainingMode, handleSpotDrillAction, submitTraining, resetTraining } from './training';
+import { showToast, setupMobileNavigation } from './ui';
+
+/**
+ * Setup navigation button event listeners
+ */
+function setupNavigation(): void {
+    // Edit mode buttons
+    const editModeButtons = document.querySelectorAll('.edit-mode-btn');
+    editModeButtons.forEach((button) => {
+        button.addEventListener('click', (e) => {
+            const target = e.target as HTMLButtonElement;
+            const action = target.dataset.action as HandAction;
+            if (action) {
+                setEditMode(action);
+            }
+        });
+    });
+    
+    // Initialize edit mode to 'raise' by default
+    setEditMode('raise');
+    
+    // Reset button
+    const resetBtn = document.getElementById('reset-btn');
+    if (resetBtn) {
+        resetBtn.addEventListener('click', resetAll);
+    }
+    
+    // Select all button
+    const selectAllBtn = document.getElementById('select-all-btn');
+    if (selectAllBtn) {
+        selectAllBtn.addEventListener('click', selectAll);
+    }
+    
+    // Save range button
+    const saveRangeBtn = document.getElementById('save-range-btn');
+    const rangeNameInput = document.getElementById('range-name-input') as HTMLInputElement;
+    
+    if (saveRangeBtn && rangeNameInput) {
+        saveRangeBtn.addEventListener('click', () => {
+            saveCurrentRange(rangeNameInput.value);
+        });
+        
+        // Allow Enter key to save
+        rangeNameInput.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                saveCurrentRange(rangeNameInput.value);
+            }
+        });
+    }
+    
+    // Set up event delegation for preset buttons (works with dynamically created buttons)
+    const presetsContainer = document.getElementById('presets-container');
+    if (presetsContainer) {
+        presetsContainer.addEventListener('click', (e) => {
+            const target = e.target as HTMLElement;
+            if (target.classList.contains('preset-button')) {
+                const presetName = target.dataset.preset;
+                if (presetName) {
+                    loadPreset(presetName);
+                }
+            }
+        });
+    }
+    
+    // Render saved ranges on load
+    renderSavedRanges();
+    
+    // Mode toggle button
+    const modeToggle = document.getElementById('mode-toggle');
+    if (modeToggle) {
+        modeToggle.addEventListener('click', () => {
+            if (currentMode === 'edit') {
+                if (Object.keys(getCurrentSelection()).length === 0) {
+                    showToast('Please select or load a range first before entering train mode.', 'error');
+                    return;
+                }
+                switchMode('train');
+            } else {
+                switchMode('edit');
+            }
+        });
+    }
+    
+    // Train mode buttons
+    const resetTrainBtn = document.getElementById('reset-train-btn');
+    if (resetTrainBtn) {
+        resetTrainBtn.addEventListener('click', resetTraining);
+    }
+    
+    const submitTrainBtn = document.getElementById('submit-train-btn');
+    if (submitTrainBtn) {
+        submitTrainBtn.addEventListener('click', submitTraining);
+    }
+    
+    // Training mode selector buttons
+    const rangeRecallBtn = document.getElementById('range-recall-btn');
+    if (rangeRecallBtn) {
+        rangeRecallBtn.addEventListener('click', () => {
+            switchTrainingMode('range-recall');
+        });
+    }
+    
+    const spotDrillBtn = document.getElementById('spot-drill-btn');
+    if (spotDrillBtn) {
+        spotDrillBtn.addEventListener('click', () => {
+            switchTrainingMode('spot-drill');
+        });
+    }
+    
+    // Spot drill action buttons
+    const spotActionButtons = document.querySelectorAll('.spot-action-btn');
+    spotActionButtons.forEach((button) => {
+        button.addEventListener('click', (e) => {
+            const target = e.target as HTMLButtonElement;
+            const action = target.dataset.action as HandAction;
+            if (action) {
+                handleSpotDrillAction(action);
+            }
+        });
+    });
+}
+
+/**
+ * Initialize the app
+ */
+async function init(): Promise<void> {
+    // Load presets from JSON file
+    await loadPresetsFromFile();
+    
+    createRangeGrid();
+    setupNavigation();
+    setupMobileNavigation();
+    updateStats();
+    
+    // Add global mouse up listener to end drag
+    document.addEventListener('mouseup', () => {
+        setIsDragging(false);
+        setDragAction(null);
+    });
+    
+    // Add global touch end listener to end drag
+    document.addEventListener('touchend', () => {
+        handleTouchEnd();
+    });
+    
+    // Add global touch cancel listener
+    document.addEventListener('touchcancel', () => {
+        handleTouchEnd();
+    });
+    
+    // Prevent text selection during drag
+    document.addEventListener('selectstart', (e) => {
+        if (isDragging) {
+            e.preventDefault();
+        }
+    });
+}
+
+// Start the app when DOM is ready
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+} else {
+    init();
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+// Poker ranks from high to low
+export const RANKS = ['A', 'K', 'Q', 'J', 'T', '9', '8', '7', '6', '5', '4', '3', '2'];
+
+// LocalStorage key for saved ranges
+export const STORAGE_KEY = 'poker-trainer-saved-ranges';
+
+// Initial number of hands for spot drill
+export const INITIAL_HANDS_COUNT = 5;

--- a/src/grid.ts
+++ b/src/grid.ts
@@ -1,0 +1,142 @@
+import { HandAction } from './types';
+import { RANKS } from './constants';
+import {
+    handsState,
+    isDragging, dragAction, isTouching, lastTouchedHand,
+    currentEditMode,
+    setIsDragging, setDragAction, setIsTouching, setLastTouchedHand
+} from './state';
+import { setHandAction } from './actions';
+
+/**
+ * Determine the hand label and type based on grid position
+ */
+export function getHandInfo(row: number, col: number): { hand: string; type: 'pair' | 'suited' | 'offsuit' } {
+    const rank1 = RANKS[row];
+    const rank2 = RANKS[col];
+    
+    if (row === col) {
+        // Diagonal: Pocket pairs
+        return { hand: `${rank1}${rank2}`, type: 'pair' };
+    } else if (row < col) {
+        // Above diagonal: Suited hands
+        return { hand: `${rank1}${rank2}s`, type: 'suited' };
+    } else {
+        // Below diagonal: Offsuit hands
+        return { hand: `${rank2}${rank1}o`, type: 'offsuit' };
+    }
+}
+
+/**
+ * Handle mouse down on a cell - start drag operation
+ */
+function handleMouseDown(hand: string, event: MouseEvent): void {
+    event.preventDefault();
+    const handState = handsState.get(hand);
+    if (!handState) return;
+    
+    setIsDragging(true);
+    
+    // Use the currently selected edit mode
+    setDragAction(currentEditMode);
+    
+    // Apply action to the clicked cell
+    setHandAction(hand, currentEditMode);
+}
+
+/**
+ * Handle mouse enter on a cell during drag
+ */
+function handleMouseEnter(hand: string): void {
+    if (!isDragging || dragAction === null) return;
+    
+    // Apply the drag action to this cell
+    setHandAction(hand, dragAction);
+}
+
+/**
+ * Handle touch start on a cell
+ */
+function handleTouchStart(hand: string, event: TouchEvent): void {
+    event.preventDefault();
+    setIsTouching(true);
+    setLastTouchedHand(hand);
+    
+    const handState = handsState.get(hand);
+    if (!handState) return;
+    
+    setIsDragging(true);
+    setDragAction(currentEditMode);
+    
+    // Apply action to the touched cell
+    setHandAction(hand, currentEditMode);
+}
+
+/**
+ * Handle touch move on a cell
+ */
+function handleTouchMove(hand: string, event: TouchEvent): void {
+    if (!isTouching || !isDragging || dragAction === null) return;
+    
+    event.preventDefault();
+    
+    // Get the element under the touch point
+    const touch = event.touches[0];
+    const element = document.elementFromPoint(touch.clientX, touch.clientY);
+    
+    if (element && element.classList.contains('hand-cell')) {
+        const touchedHand = element.getAttribute('data-hand');
+        if (touchedHand && touchedHand !== lastTouchedHand) {
+            setLastTouchedHand(touchedHand);
+            setHandAction(touchedHand, dragAction);
+        }
+    }
+}
+
+/**
+ * Handle touch end
+ */
+export function handleTouchEnd(): void {
+    setIsTouching(false);
+    setIsDragging(false);
+    setDragAction(null);
+    setLastTouchedHand(null);
+}
+
+/**
+ * Create and render the range grid
+ */
+export function createRangeGrid(): void {
+    const gridContainer = document.getElementById('range-grid');
+    if (!gridContainer) return;
+    
+    // Create 13x13 grid
+    for (let row = 0; row < 13; row++) {
+        for (let col = 0; col < 13; col++) {
+            const { hand, type } = getHandInfo(row, col);
+            
+            // Create cell element
+            const cell = document.createElement('div');
+            cell.className = 'hand-cell';
+            cell.textContent = hand;
+            cell.dataset.hand = hand;
+            
+            // Add mouse event listeners for click and drag
+            cell.addEventListener('mousedown', (e) => handleMouseDown(hand, e));
+            cell.addEventListener('mouseenter', () => handleMouseEnter(hand));
+            
+            // Add touch event listeners for mobile
+            cell.addEventListener('touchstart', (e) => handleTouchStart(hand, e), { passive: false });
+            cell.addEventListener('touchmove', (e) => handleTouchMove(hand, e), { passive: false });
+            cell.addEventListener('touchend', () => handleTouchEnd());
+            
+            // Prevent default drag behavior
+            cell.addEventListener('dragstart', (e) => e.preventDefault());
+            
+            gridContainer.appendChild(cell);
+            
+            // Initialize hand state
+            handsState.set(hand, { hand, type, action: 'fold' });
+        }
+    }
+}

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -1,0 +1,141 @@
+import { HandAction, PresetsData } from './types';
+import { loadedPresets, setLoadedPresets, setCurrentLoadedPresetKey } from './state';
+import { setHandAction, resetAll } from './actions';
+import { handsState } from './state';
+
+/**
+ * Load presets from JSON file
+ */
+export async function loadPresetsFromFile(): Promise<void> {
+    try {
+        const response = await fetch('presets.json');
+        if (!response.ok) {
+            console.error('Failed to load presets.json');
+            return;
+        }
+        setLoadedPresets(await response.json());
+        console.log('Presets loaded successfully:', Object.keys(loadedPresets));
+        // Render preset buttons after loading
+        renderPresetButtons();
+    } catch (error) {
+        console.error('Error loading presets:', error);
+    }
+}
+
+/**
+ * Render preset buttons dynamically from loaded presets
+ */
+export function renderPresetButtons(): void {
+    const container = document.getElementById('presets-container');
+    if (!container) return;
+    
+    // Clear existing buttons
+    container.innerHTML = '';
+    
+    // Get all preset keys and sort them for consistent ordering
+    const presetKeys = Object.keys(loadedPresets).sort();
+    
+    if (presetKeys.length === 0) {
+        container.innerHTML = '<p class="empty-message">No presets available</p>';
+        return;
+    }
+    
+    // Create a button for each preset
+    presetKeys.forEach((presetKey) => {
+        const preset = loadedPresets[presetKey];
+        const button = document.createElement('button');
+        button.className = 'preset-button';
+        button.dataset.preset = presetKey;
+        button.textContent = preset.name || presetKey;
+        button.title = preset.description || `Load ${preset.name || presetKey}`;
+        container.appendChild(button);
+    });
+}
+
+/**
+ * Load a preset range
+ */
+export function loadPreset(presetName: string): void {
+    const preset = loadedPresets[presetName];
+    if (!preset) {
+        console.warn(`Preset "${presetName}" not found`);
+        return;
+    }
+    
+    // Store the current preset info for train mode
+    setCurrentLoadedPresetKey(presetName);
+    
+    // Check format type
+    if (Array.isArray(preset.hands)) {
+        // Format 1: Simple array - all hands are raise
+        loadHandsArray(preset.hands);
+    } else if (typeof preset.hands === 'object') {
+        // Check if it's Format 2 (hand->action) or Format 3 (action->hands[])
+        const firstKey = Object.keys(preset.hands)[0];
+        const firstValue = preset.hands[firstKey];
+        
+        if (Array.isArray(firstValue)) {
+            // Format 3: Grouped by action {"raise": ["AA", "KK"], "call": ["QQ"]}
+            loadHandsGroupedByAction(preset.hands as { [action: string]: string[] });
+        } else {
+            // Format 2: Hand to action mapping {"AA": "raise", "KK": "call"}
+            loadHandsWithActions(preset.hands as { [hand: string]: HandAction });
+        }
+    }
+}
+
+/**
+ * Load hands grouped by action (new format)
+ */
+export function loadHandsGroupedByAction(groupedHands: { [action: string]: string[] }): void {
+    // First clear all
+    resetAll();
+    
+    // Then apply each action group
+    Object.keys(groupedHands).forEach((action) => {
+        const hands = groupedHands[action];
+        if (Array.isArray(hands)) {
+            hands.forEach((hand) => {
+                const handState = handsState.get(hand);
+                // Support legacy 'mix' as 'mix-rc' for backward compatibility
+                const normalizedAction = action === 'mix' ? 'mix-rc' : action;
+                if (handState && (normalizedAction === 'raise' || normalizedAction === 'call' || normalizedAction === 'mix-rc' || normalizedAction === 'mix-rf' || normalizedAction === 'fold')) {
+                    setHandAction(hand, normalizedAction as HandAction);
+                }
+            });
+        }
+    });
+}
+
+/**
+ * Load a specific array of hands (legacy format - all as raise)
+ */
+export function loadHandsArray(hands: string[]): void {
+    // First clear all
+    resetAll();
+    
+    // Then select the specified hands as raise
+    hands.forEach((hand) => {
+        const handState = handsState.get(hand);
+        if (handState) {
+            setHandAction(hand, 'raise');
+        }
+    });
+}
+
+/**
+ * Load hands with specific actions
+ */
+export function loadHandsWithActions(handsMap: { [hand: string]: HandAction }): void {
+    // First clear all
+    resetAll();
+    
+    // Then apply actions
+    Object.keys(handsMap).forEach((hand) => {
+        const action = handsMap[hand];
+        const handState = handsState.get(hand);
+        if (handState && action !== 'fold') {
+            setHandAction(hand, action);
+        }
+    });
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,42 @@
+import { HandAction, HandCell, PresetsData, AppMode, TrainingMode, SpotDrillState } from './types';
+
+// Store the state of all hands
+export const handsState: Map<string, HandCell> = new Map();
+
+// Track drag state
+export let isDragging = false;
+export let dragAction: HandAction | null = null;
+export let isTouching = false;
+export let lastTouchedHand: string | null = null;
+
+// Current edit mode (default to 'raise')
+export let currentEditMode: HandAction = 'raise';
+
+// Store loaded presets
+export let loadedPresets: PresetsData = {};
+
+// App mode
+export let currentMode: AppMode = 'edit';
+export let currentTrainingMode: TrainingMode = 'range-recall';
+export let trainingRange: { [hand: string]: HandAction } | null = null;
+export let trainingRangeName: string = '';
+export let trainingRangeDescription: string = '';
+export let currentLoadedPresetKey: string = '';
+
+// Spot Drill state
+export let spotDrillState: SpotDrillState | null = null;
+
+// State setters (needed because ES modules export bindings, not references for let)
+export function setIsDragging(value: boolean): void { isDragging = value; }
+export function setDragAction(value: HandAction | null): void { dragAction = value; }
+export function setIsTouching(value: boolean): void { isTouching = value; }
+export function setLastTouchedHand(value: string | null): void { lastTouchedHand = value; }
+export function setCurrentEditMode(value: HandAction): void { currentEditMode = value; }
+export function setLoadedPresets(value: PresetsData): void { loadedPresets = value; }
+export function setCurrentMode(value: AppMode): void { currentMode = value; }
+export function setCurrentTrainingMode(value: TrainingMode): void { currentTrainingMode = value; }
+export function setTrainingRange(value: { [hand: string]: HandAction } | null): void { trainingRange = value; }
+export function setTrainingRangeName(value: string): void { trainingRangeName = value; }
+export function setTrainingRangeDescription(value: string): void { trainingRangeDescription = value; }
+export function setCurrentLoadedPresetKey(value: string): void { currentLoadedPresetKey = value; }
+export function setSpotDrillState(value: SpotDrillState | null): void { spotDrillState = value; }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,274 @@
+import { HandAction, SavedRange } from './types';
+import { STORAGE_KEY } from './constants';
+import { handsState } from './state';
+import { getCurrentSelection } from './actions';
+import { showToast, showConfirm } from './ui';
+import { loadHandsArray, loadHandsWithActions } from './presets';
+
+/**
+ * Get all saved ranges from localStorage
+ */
+export function getSavedRanges(): SavedRange[] {
+    try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (!stored) return [];
+        return JSON.parse(stored) as SavedRange[];
+    } catch (error) {
+        console.error('Error reading saved ranges:', error);
+        return [];
+    }
+}
+
+/**
+ * Save ranges to localStorage
+ */
+export function saveSavedRanges(ranges: SavedRange[]): void {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(ranges));
+    } catch (error) {
+        console.error('Error saving ranges:', error);
+        showToast('Failed to save range. Storage may be full or disabled.', 'error');
+    }
+}
+
+/**
+ * Save current selection as a named range
+ */
+export function saveCurrentRange(name: string): void {
+    if (!name.trim()) {
+        showToast('Please enter a name for your range.', 'error');
+        return;
+    }
+    
+    const selected = getCurrentSelection();
+    if (Object.keys(selected).length === 0) {
+        showToast('Please select at least one hand before saving.', 'error');
+        return;
+    }
+    
+    const ranges = getSavedRanges();
+    
+    // Check if name already exists
+    const existingIndex = ranges.findIndex(r => r.name === name.trim());
+    
+    const newRange: SavedRange = {
+        name: name.trim(),
+        hands: selected,
+        timestamp: Date.now()
+    };
+    
+    if (existingIndex >= 0) {
+        // Update existing range - use async confirmation
+        showConfirm(`A range named "${name.trim()}" already exists. Overwrite it?`).then((confirmed) => {
+            if (confirmed) {
+                // Get fresh ranges to avoid race conditions
+                const currentRanges = getSavedRanges();
+                const currentIndex = currentRanges.findIndex(r => r.name === name.trim());
+                if (currentIndex >= 0) {
+                    currentRanges[currentIndex] = newRange;
+                } else {
+                    currentRanges.push(newRange);
+                }
+                saveSavedRanges(currentRanges);
+                renderSavedRanges();
+                
+                // Clear input field
+                const input = document.getElementById('range-name-input') as HTMLInputElement;
+                if (input) {
+                    input.value = '';
+                }
+                
+                showToast(`Range "${name.trim()}" saved successfully!`, 'success');
+            }
+        });
+        return;
+    } else {
+        // Add new range
+        ranges.push(newRange);
+    }
+    
+    saveSavedRanges(ranges);
+    renderSavedRanges();
+    
+    // Clear input field
+    const input = document.getElementById('range-name-input') as HTMLInputElement;
+    if (input) {
+        input.value = '';
+    }
+    
+    showToast(`Range "${name.trim()}" saved successfully!`, 'success');
+}
+
+/**
+ * Load a saved range
+ */
+export function loadSavedRange(name: string): void {
+    const ranges = getSavedRanges();
+    const range = ranges.find(r => r.name === name);
+    
+    if (range) {
+        // Check if it's the new format (object) or old format (array)
+        if (Array.isArray(range.hands)) {
+            // Legacy format - convert to raise actions
+            loadHandsArray(range.hands);
+        } else {
+            // New format with actions
+            loadHandsWithActions(range.hands);
+        }
+    }
+}
+
+/**
+ * Delete a saved range
+ */
+export function deleteSavedRange(name: string): void {
+    showConfirm(`Are you sure you want to delete "${name}"?`).then((confirmed) => {
+        if (confirmed) {
+            const ranges = getSavedRanges();
+            const filtered = ranges.filter(r => r.name !== name);
+            
+            saveSavedRanges(filtered);
+            renderSavedRanges();
+            showToast(`Range "${name}" deleted successfully.`, 'success');
+        }
+    });
+}
+
+/**
+ * Convert a saved range to presets.json compatible format
+ */
+export function formatRangeForPresets(range: SavedRange): string {
+    // Group hands by action (exclude fold actions)
+    const groupedByAction: { [action: string]: string[] } = {
+        raise: [],
+        call: [],
+        'mix-rc': [],
+        'mix-rf': []
+    };
+    
+    // Handle both old format (array) and new format (object)
+    if (Array.isArray(range.hands)) {
+        // Legacy format - all hands are raise
+        groupedByAction.raise = range.hands;
+    } else {
+        // New format with actions
+        Object.keys(range.hands).forEach((hand) => {
+            const action = range.hands[hand];
+            if (action !== 'fold' && groupedByAction[action]) {
+                groupedByAction[action].push(hand);
+            }
+        });
+    }
+    
+    // Create preset object matching presets.json structure
+    const preset = {
+        name: range.name,
+        description: `Custom range: ${range.name}`,
+        hands: groupedByAction
+    };
+    
+    // Generate a key from the range name (lowercase, replace spaces with hyphens)
+    const key = range.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+    
+    // Format as JSON with proper indentation, including the key
+    // This makes it easy to paste directly into presets.json
+    const presetWithKey = {
+        [key]: preset
+    };
+    
+    return JSON.stringify(presetWithKey, null, 2);
+}
+
+/**
+ * Copy a saved range to clipboard as presets.json compatible JSON
+ */
+export async function copyRangeToClipboard(name: string): Promise<void> {
+    const ranges = getSavedRanges();
+    const range = ranges.find(r => r.name === name);
+    
+    if (!range) {
+        showToast(`Range "${name}" not found.`, 'error');
+        return;
+    }
+    
+    try {
+        const jsonString = formatRangeForPresets(range);
+        await navigator.clipboard.writeText(jsonString);
+        showToast(`Range "${name}" copied to clipboard! You can now paste it into presets.json`, 'success');
+    } catch (error) {
+        console.error('Failed to copy to clipboard:', error);
+        // Fallback for older browsers
+        const textArea = document.createElement('textarea');
+        textArea.value = formatRangeForPresets(range);
+        textArea.style.position = 'fixed';
+        textArea.style.opacity = '0';
+        document.body.appendChild(textArea);
+        textArea.select();
+        try {
+            document.execCommand('copy');
+            showToast(`Range "${name}" copied to clipboard! You can now paste it into presets.json`, 'success');
+        } catch (fallbackError) {
+            showToast('Failed to copy to clipboard. Please check your browser permissions.', 'error');
+        }
+        document.body.removeChild(textArea);
+    }
+}
+
+/**
+ * Render the list of saved ranges
+ */
+export function renderSavedRanges(): void {
+    const container = document.getElementById('saved-ranges-list');
+    if (!container) return;
+    
+    const ranges = getSavedRanges();
+    
+    if (ranges.length === 0) {
+        container.innerHTML = '<p class="empty-message">No saved ranges yet</p>';
+        return;
+    }
+    
+    // Sort by timestamp (newest first)
+    ranges.sort((a, b) => b.timestamp - a.timestamp);
+    
+    container.innerHTML = '';
+    
+    ranges.forEach((range) => {
+        const item = document.createElement('div');
+        item.className = 'saved-range-item';
+        
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'saved-range-name';
+        nameSpan.textContent = range.name;
+        const handCount = Array.isArray(range.hands) ? range.hands.length : Object.keys(range.hands).length;
+        nameSpan.title = `${handCount} hands - Click to load`;
+        nameSpan.addEventListener('click', () => loadSavedRange(range.name));
+        
+        const buttonContainer = document.createElement('div');
+        buttonContainer.className = 'range-action-buttons';
+        
+        const copyBtn = document.createElement('button');
+        copyBtn.className = 'copy-range-btn';
+        copyBtn.innerHTML = '📋';
+        copyBtn.title = 'Copy to clipboard (presets.json format)';
+        copyBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            copyRangeToClipboard(range.name);
+        });
+        
+        const deleteBtn = document.createElement('button');
+        deleteBtn.className = 'delete-range-btn';
+        deleteBtn.innerHTML = '×';
+        deleteBtn.title = 'Delete range';
+        deleteBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            deleteSavedRange(range.name);
+        });
+        
+        buttonContainer.appendChild(copyBtn);
+        buttonContainer.appendChild(deleteBtn);
+        item.appendChild(nameSpan);
+        item.appendChild(buttonContainer);
+        container.appendChild(item);
+    });
+}

--- a/src/training.ts
+++ b/src/training.ts
@@ -1,0 +1,522 @@
+import { HandAction, SpotDrillState } from './types';
+import { INITIAL_HANDS_COUNT } from './constants';
+import {
+    handsState, loadedPresets,
+    currentMode, currentTrainingMode, currentEditMode,
+    trainingRange, trainingRangeName, trainingRangeDescription,
+    currentLoadedPresetKey, spotDrillState,
+    setCurrentMode, setCurrentTrainingMode,
+    setTrainingRange, setTrainingRangeName, setTrainingRangeDescription,
+    setSpotDrillState
+} from './state';
+import { setHandAction, resetAll, getCurrentSelection, setEditMode } from './actions';
+import { loadHandsWithActions } from './presets';
+import { showToast } from './ui';
+
+/**
+ * Switch between edit and train modes
+ */
+export function switchMode(mode: 'edit' | 'train'): void {
+    setCurrentMode(mode);
+    
+    const navBar = document.querySelector('.nav-bar') as HTMLElement;
+    const editElements = document.querySelectorAll('.edit-only');
+    const trainElements = document.querySelectorAll('.train-only');
+    const modeToggle = document.getElementById('mode-toggle');
+    
+    if (mode === 'train') {
+        // Keep nav bar visible for mode toggle button, but hide other nav sections
+        if (navBar) navBar.style.display = 'block';
+        const navSections = navBar.querySelectorAll('.nav-section');
+        navSections.forEach((section, index) => {
+            // Keep first section (mode toggle) visible, hide others
+            if (index > 0) {
+                (section as HTMLElement).style.display = 'none';
+            }
+        });
+        editElements.forEach(el => (el as HTMLElement).style.display = 'none');
+        trainElements.forEach(el => (el as HTMLElement).style.display = 'block');
+        
+        // Store current range as training target
+        setTrainingRange(getCurrentSelection());
+        
+        // Get preset info if available
+        if (currentLoadedPresetKey && loadedPresets[currentLoadedPresetKey]) {
+            const preset = loadedPresets[currentLoadedPresetKey];
+            setTrainingRangeName(preset.name);
+            setTrainingRangeDescription(preset.description);
+        } else {
+            setTrainingRangeName('Custom Range');
+            setTrainingRangeDescription('User-created range');
+        }
+        
+        // Display range info
+        const rangeInfoDiv = document.getElementById('train-range-info');
+        if (rangeInfoDiv) {
+            rangeInfoDiv.innerHTML = `
+                <h2>${trainingRangeName}</h2>
+                <p class="range-description">${trainingRangeDescription}</p>
+            `;
+        }
+        
+        const spotDrillRangeInfoDiv = document.getElementById('spot-drill-range-info');
+        if (spotDrillRangeInfoDiv) {
+            spotDrillRangeInfoDiv.innerHTML = `
+                <h2>${trainingRangeName}</h2>
+                <p class="range-description">${trainingRangeDescription}</p>
+            `;
+        }
+        
+        // Clear the grid for practice
+        resetAll();
+        
+        // Ensure edit mode button states are synced
+        setEditMode(currentEditMode);
+        
+        // Update training mode display
+        updateTrainingModeDisplay();
+        
+        // Update toggle button
+        if (modeToggle) modeToggle.textContent = '← Back to Edit Mode';
+    } else {
+        // Show navigation and edit elements
+        if (navBar) navBar.style.display = 'block';
+        // Show all nav sections
+        const navSections = navBar.querySelectorAll('.nav-section');
+        navSections.forEach((section) => {
+            (section as HTMLElement).style.display = 'block';
+        });
+        editElements.forEach(el => (el as HTMLElement).style.display = 'block');
+        trainElements.forEach(el => (el as HTMLElement).style.display = 'none');
+        
+        // Restore the training range to the grid
+        const rangeGrid = document.getElementById('range-grid');
+        if (rangeGrid) {
+            rangeGrid.style.display = 'grid';
+        }
+        
+        if (trainingRange) {
+            loadHandsWithActions(trainingRange);
+        }
+        
+        // Clear training data
+        setTrainingRange(null);
+        setTrainingRangeName('');
+        setTrainingRangeDescription('');
+        setSpotDrillState(null);
+        
+        // Ensure edit mode button states are synced
+        setEditMode(currentEditMode);
+        
+        // Update toggle button
+        if (modeToggle) modeToggle.textContent = 'Switch to Train Mode →';
+    }
+}
+
+/**
+ * Switch between training modes (Range Recall vs Spot Drill)
+ */
+export function switchTrainingMode(mode: 'range-recall' | 'spot-drill'): void {
+    setCurrentTrainingMode(mode);
+    updateTrainingModeDisplay();
+    
+    if (mode === 'spot-drill') {
+        startSpotDrill();
+    } else {
+        stopSpotDrill();
+    }
+}
+
+/**
+ * Update the display based on current training mode
+ */
+export function updateTrainingModeDisplay(): void {
+    const rangeRecallMode = document.querySelector('.range-recall-mode') as HTMLElement;
+    const spotDrillMode = document.querySelector('.spot-drill-mode') as HTMLElement;
+    const rangeGrid = document.getElementById('range-grid');
+    const trainControls = document.querySelector('.train-controls') as HTMLElement;
+    const trainResult = document.getElementById('train-result');
+    const spotDrillResult = document.getElementById('spot-drill-result');
+    const rangeRecallBtn = document.getElementById('range-recall-btn');
+    const spotDrillBtn = document.getElementById('spot-drill-btn');
+    
+    if (currentTrainingMode === 'spot-drill') {
+        if (rangeRecallMode) rangeRecallMode.style.display = 'none';
+        if (spotDrillMode) spotDrillMode.style.display = 'block';
+        if (rangeGrid) rangeGrid.style.display = 'none';
+        if (trainControls) trainControls.style.display = 'none';
+        if (trainResult) trainResult.style.display = 'none';
+        if (rangeRecallBtn) rangeRecallBtn.classList.remove('active');
+        if (spotDrillBtn) spotDrillBtn.classList.add('active');
+    } else {
+        if (rangeRecallMode) rangeRecallMode.style.display = 'block';
+        if (spotDrillMode) spotDrillMode.style.display = 'none';
+        if (rangeGrid) rangeGrid.style.display = 'grid';
+        if (trainControls) trainControls.style.display = 'flex';
+        if (spotDrillResult) spotDrillResult.style.display = 'none';
+        if (rangeRecallBtn) rangeRecallBtn.classList.add('active');
+        if (spotDrillBtn) spotDrillBtn.classList.remove('active');
+    }
+}
+
+/**
+ * Generate a shuffled array of hands from the training range
+ */
+export function generateHandsQueue(count: number, excludeHands?: string[]): string[] {
+    if (!trainingRange) return [];
+    
+    let hands = Object.keys(trainingRange);
+    
+    // Exclude hands that have already been shown
+    if (excludeHands && excludeHands.length > 0) {
+        const excludeSet = new Set(excludeHands);
+        hands = hands.filter(hand => !excludeSet.has(hand));
+    }
+    
+    // If we've exhausted all hands, shuffle and start over
+    if (hands.length === 0) {
+        hands = Object.keys(trainingRange);
+    }
+    
+    const shuffled = [...hands].sort(() => Math.random() - 0.5);
+    return shuffled.slice(0, Math.min(count, shuffled.length));
+}
+
+/**
+ * Start a new Spot Drill session
+ */
+export function startSpotDrill(): void {
+    if (!trainingRange) return;
+    
+    const initialHands = generateHandsQueue(INITIAL_HANDS_COUNT);
+    
+    setSpotDrillState({
+        handsQueue: initialHands,
+        currentHandIndex: 0,
+        correctAnswers: 0,
+        totalAttempts: 0,
+        results: []
+    });
+    
+    // Show first hand
+    displayNextHand();
+    updateSpotDrillProgress();
+    
+    // Hide results if showing
+    const resultDiv = document.getElementById('spot-drill-result');
+    if (resultDiv) resultDiv.style.display = 'none';
+}
+
+/**
+ * Stop Spot Drill and reset state
+ */
+export function stopSpotDrill(): void {
+    setSpotDrillState(null);
+}
+
+/**
+ * Parse a hand notation string to extract card ranks
+ * Examples: "QJs" -> ["Q", "J"], "AA" -> ["A", "A"], "KQo" -> ["K", "Q"]
+ */
+export function parseHand(hand: string): { rank1: string; rank2: string; suited: boolean } {
+    // Remove trailing 's' (suited) or 'o' (offsuit) if present
+    const cleanHand = hand.replace(/[so]$/, '');
+    const suited = hand.endsWith('s');
+    
+    if (cleanHand.length === 2) {
+        // Pocket pair or two different ranks
+        return {
+            rank1: cleanHand[0],
+            rank2: cleanHand[1],
+            suited
+        };
+    }
+    
+    // Fallback for unexpected formats
+    return { rank1: '?', rank2: '?', suited: false };
+}
+
+/**
+ * Get color for a card based on rank (for visualization)
+ * Uses only four colors: red, green, blue, and black
+ */
+export function getCardColor(rank: string, index: number, suited: boolean): string {
+    // Only four colors: red, green, blue, black
+    // Assign colors based on rank for consistency
+    const rankColors: { [key: string]: string } = {
+        'A': '#dc3545', // Red
+        'K': '#000000', // Black
+        'Q': '#007bff', // Blue
+        'J': '#28a745', // Green
+        'T': '#dc3545', // Red
+        '9': '#28a745', // Green
+        '8': '#007bff', // Blue
+        '7': '#000000', // Black
+        '6': '#dc3545', // Red
+        '5': '#28a745', // Green
+        '4': '#007bff', // Blue
+        '3': '#000000', // Black
+        '2': '#dc3545', // Red
+    };
+    
+    // Use rank-based color, or fallback to index-based
+    if (rankColors[rank]) {
+        return rankColors[rank];
+    }
+    
+    // Fallback: index-based coloring with four colors only
+    if (index === 0) {
+        return '#dc3545'; // Red
+    } else {
+        if (suited) {
+            return '#28a745'; // Green for suited
+        } else {
+            return '#007bff'; // Blue for offsuit
+        }
+    }
+}
+
+/**
+ * Create a card element as a colored square with letter
+ */
+export function createCardElement(rank: string, color: string): HTMLElement {
+    const card = document.createElement('div');
+    card.className = 'card-square';
+    card.textContent = rank;
+    card.style.backgroundColor = color;
+    return card;
+}
+
+/**
+ * Display the next hand in the queue with visual card representation
+ */
+export function displayNextHand(): void {
+    if (!spotDrillState || spotDrillState.currentHandIndex >= spotDrillState.handsQueue.length) {
+        // All hands shown, show results
+        showSpotDrillResults();
+        return;
+    }
+    
+    const currentHand = spotDrillState.handsQueue[spotDrillState.currentHandIndex];
+    const { rank1, rank2, suited } = parseHand(currentHand);
+    
+    // Display in table center only
+    const handDisplay = document.getElementById('current-hand-display');
+    if (handDisplay) {
+        handDisplay.innerHTML = '';
+        
+        // Create card elements
+        const card1 = createCardElement(rank1, getCardColor(rank1, 0, suited));
+        const card2 = createCardElement(rank2, getCardColor(rank2, 1, suited));
+        
+        handDisplay.appendChild(card1);
+        handDisplay.appendChild(card2);
+    }
+}
+
+/**
+ * Handle action selection in Spot Drill
+ */
+export function handleSpotDrillAction(action: HandAction): void {
+    if (!spotDrillState || !trainingRange) return;
+    
+    const currentHand = spotDrillState.handsQueue[spotDrillState.currentHandIndex];
+    const correctAction = trainingRange[currentHand];
+    
+    const isCorrect = action === correctAction;
+    
+    // Record result
+    spotDrillState.results.push({
+        hand: currentHand,
+        correctAction: correctAction,
+        userAction: action,
+        correct: isCorrect
+    });
+    
+    if (isCorrect) {
+        spotDrillState.correctAnswers++;
+        showToast('✓ Correct!', 'success');
+    } else {
+        showToast(`✗ Wrong! Correct action: ${correctAction.charAt(0).toUpperCase() + correctAction.slice(1)}`, 'error');
+    }
+    
+    spotDrillState.totalAttempts++;
+    spotDrillState.currentHandIndex++;
+    
+    updateSpotDrillProgress();
+    
+    // Show next hand after a brief delay
+    setTimeout(() => {
+        displayNextHand();
+    }, 1000);
+}
+
+/**
+ * Update progress display
+ */
+export function updateSpotDrillProgress(): void {
+    if (!spotDrillState) return;
+    
+    const progressText = document.getElementById('spot-drill-progress-text');
+    if (progressText) {
+        const completed = spotDrillState.currentHandIndex;
+        const total = spotDrillState.handsQueue.length;
+        progressText.textContent = `${completed} / ${total}`;
+    }
+}
+
+/**
+ * Show Spot Drill results
+ */
+export function showSpotDrillResults(): void {
+    if (!spotDrillState) return;
+    
+    const resultDiv = document.getElementById('spot-drill-result');
+    if (!resultDiv) return;
+    
+    const accuracy = spotDrillState.totalAttempts > 0 
+        ? ((spotDrillState.correctAnswers / spotDrillState.totalAttempts) * 100).toFixed(1) 
+        : '0.0';
+    
+    const resultsHtml = `
+        <h3>Spot Drill Results</h3>
+        <p class="accuracy">Accuracy: ${accuracy}%</p>
+        <p>✓ Correct: ${spotDrillState.correctAnswers} / ${spotDrillState.totalAttempts}</p>
+        <div class="spot-drill-results-actions">
+            <button id="continue-drill-btn" class="train-button submit-button">Continue Drilling</button>
+            <button id="restart-drill-btn" class="train-button reset-button">Restart</button>
+        </div>
+    `;
+    
+    resultDiv.innerHTML = resultsHtml;
+    resultDiv.style.display = 'block';
+    
+    // Setup continue and restart buttons
+    const continueBtn = document.getElementById('continue-drill-btn');
+    const restartBtn = document.getElementById('restart-drill-btn');
+    
+    if (continueBtn) {
+        // Remove old event listener by cloning and replacing
+        const newContinueBtn = continueBtn.cloneNode(true);
+        continueBtn.parentNode?.replaceChild(newContinueBtn, continueBtn);
+        
+        newContinueBtn.addEventListener('click', () => {
+            // Add more hands to queue, excluding already shown hands
+            if (spotDrillState) {
+                const shownHands = spotDrillState.results.map(r => r.hand);
+                const additionalHands = generateHandsQueue(INITIAL_HANDS_COUNT, shownHands);
+                if (additionalHands.length > 0) {
+                    spotDrillState.handsQueue = [...spotDrillState.handsQueue, ...additionalHands];
+                    resultDiv.style.display = 'none';
+                    displayNextHand();
+                } else {
+                    // All hands have been shown, show final results
+                    showSpotDrillResults();
+                }
+            }
+        });
+    }
+    
+    if (restartBtn) {
+        // Remove old event listener by cloning and replacing
+        const newRestartBtn = restartBtn.cloneNode(true);
+        restartBtn.parentNode?.replaceChild(newRestartBtn, restartBtn);
+        
+        newRestartBtn.addEventListener('click', () => {
+            startSpotDrill();
+        });
+    }
+}
+
+/**
+ * Submit training attempt and show results
+ */
+export function submitTraining(): void {
+    if (!trainingRange) return;
+    
+    const userAttempt = getCurrentSelection();
+    let correct = 0;
+    let incorrect = 0;
+    let missed = 0;
+    const totalHands = Object.keys(trainingRange).length;
+    
+    // Clear all visual states first
+    handsState.forEach((handState) => {
+        const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
+        if (cell) {
+            cell.classList.remove('train-correct', 'train-incorrect', 'train-missed');
+        }
+    });
+    
+    // Check each hand in the training range
+    Object.keys(trainingRange).forEach((hand) => {
+        const correctAction = trainingRange![hand];
+        const userAction = userAttempt[hand];
+        const cell = document.querySelector(`[data-hand="${hand}"]`);
+        
+        if (userAction === correctAction) {
+            // Correct
+            correct++;
+            if (cell) cell.classList.add('train-correct');
+        } else if (userAction && userAction !== correctAction) {
+            // Wrong action
+            incorrect++;
+            if (cell) cell.classList.add('train-incorrect');
+        } else {
+            // Missed
+            missed++;
+            if (cell) cell.classList.add('train-missed');
+        }
+    });
+    
+    // Check for extra hands user added that shouldn't be there
+    Object.keys(userAttempt).forEach((hand) => {
+        if (!trainingRange![hand]) {
+            incorrect++;
+            const cell = document.querySelector(`[data-hand="${hand}"]`);
+            if (cell) cell.classList.add('train-incorrect');
+        }
+    });
+    
+    // Calculate accuracy
+    const accuracy = totalHands > 0 ? ((correct / totalHands) * 100).toFixed(1) : '0.0';
+    
+    // Show results
+    const resultDiv = document.getElementById('train-result');
+    if (resultDiv) {
+        resultDiv.innerHTML = `
+            <h3>Results</h3>
+            <p class="accuracy">Accuracy: ${accuracy}%</p>
+            <p>✓ Correct: ${correct} / ${totalHands}</p>
+            <p>✗ Incorrect: ${incorrect}</p>
+            <p>⊗ Missed: ${missed}</p>
+            <p class="result-legend">Green border = Correct | Red border = Incorrect | Yellow border = Missed</p>
+        `;
+        resultDiv.style.display = 'block';
+        resultDiv.classList.remove('pulse-animation');
+        // Trigger reflow to restart animation
+        void resultDiv.offsetWidth;
+        resultDiv.classList.add('pulse-animation');
+    }
+}
+
+/**
+ * Reset training attempt
+ */
+export function resetTraining(): void {
+    resetAll();
+    
+    // Clear result display
+    const resultDiv = document.getElementById('train-result');
+    if (resultDiv) {
+        resultDiv.style.display = 'none';
+    }
+    
+    // Clear training visual states
+    handsState.forEach((handState) => {
+        const cell = document.querySelector(`[data-hand="${handState.hand}"]`);
+        if (cell) {
+            cell.classList.remove('train-correct', 'train-incorrect', 'train-missed');
+        }
+    });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,41 @@
+// Action types for hands
+export type HandAction = 'fold' | 'raise' | 'call' | 'mix-rc' | 'mix-rf';
+
+// Type for a hand cell
+export interface HandCell {
+    hand: string;
+    type: 'pair' | 'suited' | 'offsuit';
+    action: HandAction;
+}
+
+// Interface for saved ranges
+export interface SavedRange {
+    name: string;
+    hands: { [hand: string]: HandAction };
+    timestamp: number;
+}
+
+// Interface for preset structure (supports multiple formats)
+export interface Preset {
+    name: string;
+    description: string;
+    hands: string[] | { [hand: string]: HandAction } | { [action: string]: string[] };
+}
+
+// Interface for presets file
+export interface PresetsData {
+    [key: string]: Preset;
+}
+
+// App mode
+export type AppMode = 'edit' | 'train';
+export type TrainingMode = 'range-recall' | 'spot-drill';
+
+// Spot Drill state
+export interface SpotDrillState {
+    handsQueue: string[];
+    currentHandIndex: number;
+    correctAnswers: number;
+    totalAttempts: number;
+    results: Array<{ hand: string; correctAction: HandAction; userAction: HandAction; correct: boolean }>;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,0 +1,157 @@
+/**
+ * Show a toast notification
+ */
+export function showToast(message: string, type: 'success' | 'error'): void {
+    const container = document.getElementById('toast-container');
+    if (!container) return;
+    
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.textContent = message;
+    
+    container.appendChild(toast);
+    
+    // Trigger animation
+    setTimeout(() => {
+        toast.classList.add('show');
+    }, 10);
+    
+    // Remove after animation
+    setTimeout(() => {
+        toast.classList.remove('show');
+        setTimeout(() => {
+            container.removeChild(toast);
+        }, 300);
+    }, 2000);
+}
+
+/**
+ * Show a confirmation dialog using a modal
+ * Returns a Promise that resolves to true if confirmed, false if cancelled
+ */
+export function showConfirm(message: string): Promise<boolean> {
+    return new Promise((resolve) => {
+        // Create modal overlay
+        const overlay = document.createElement('div');
+        overlay.className = 'confirm-modal-overlay';
+        
+        // Create modal
+        const modal = document.createElement('div');
+        modal.className = 'confirm-modal';
+        
+        // Create message
+        const messageDiv = document.createElement('div');
+        messageDiv.className = 'confirm-message';
+        messageDiv.textContent = message;
+        
+        // Create buttons container
+        const buttonsDiv = document.createElement('div');
+        buttonsDiv.className = 'confirm-buttons';
+        
+        // Create confirm button
+        const confirmBtn = document.createElement('button');
+        confirmBtn.className = 'confirm-btn confirm-btn-ok';
+        confirmBtn.textContent = 'OK';
+        confirmBtn.addEventListener('click', () => {
+            document.body.removeChild(overlay);
+            resolve(true);
+        });
+        
+        // Create cancel button
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'confirm-btn confirm-btn-cancel';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.addEventListener('click', () => {
+            document.body.removeChild(overlay);
+            resolve(false);
+        });
+        
+        // Assemble modal
+        buttonsDiv.appendChild(confirmBtn);
+        buttonsDiv.appendChild(cancelBtn);
+        modal.appendChild(messageDiv);
+        modal.appendChild(buttonsDiv);
+        overlay.appendChild(modal);
+        
+        // Add to DOM
+        document.body.appendChild(overlay);
+        
+        // Trigger animation
+        setTimeout(() => {
+            overlay.classList.add('show');
+        }, 10);
+        
+        // Handle escape key
+        const handleEscape = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                document.body.removeChild(overlay);
+                document.removeEventListener('keydown', handleEscape);
+                resolve(false);
+            }
+        };
+        document.addEventListener('keydown', handleEscape);
+    });
+}
+
+/**
+ * Setup mobile navigation toggle
+ */
+export function setupMobileNavigation(): void {
+    const mobileNavToggle = document.getElementById('mobile-nav-toggle');
+    const navBar = document.getElementById('nav-bar');
+    const navBackdrop = document.getElementById('nav-backdrop');
+    const hamburgerIcon = mobileNavToggle?.querySelector('.hamburger-icon') as HTMLElement;
+    const closeIcon = mobileNavToggle?.querySelector('.close-icon') as HTMLElement;
+    
+    if (!mobileNavToggle || !navBar || !navBackdrop) return;
+    
+    function openNav(): void {
+        navBar!.classList.add('mobile-open');
+        navBackdrop!.classList.add('show');
+        if (hamburgerIcon) hamburgerIcon.style.display = 'none';
+        if (closeIcon) closeIcon.style.display = 'block';
+        // Prevent body scroll when nav is open
+        document.body.style.overflow = 'hidden';
+    }
+    
+    function closeNav(): void {
+        navBar!.classList.remove('mobile-open');
+        navBackdrop!.classList.remove('show');
+        if (hamburgerIcon) hamburgerIcon.style.display = 'block';
+        if (closeIcon) closeIcon.style.display = 'none';
+        // Restore body scroll
+        document.body.style.overflow = '';
+    }
+    
+    // Toggle nav on button click
+    mobileNavToggle.addEventListener('click', () => {
+        if (navBar.classList.contains('mobile-open')) {
+            closeNav();
+        } else {
+            openNav();
+        }
+    });
+    
+    // Close nav on backdrop click
+    navBackdrop.addEventListener('click', () => {
+        closeNav();
+    });
+    
+    // Close nav when clicking a nav button (optional - for better UX)
+    const navButtons = navBar.querySelectorAll('.nav-button, .preset-button, .mode-toggle-btn');
+    navButtons.forEach(button => {
+        button.addEventListener('click', () => {
+            // Small delay to allow the action to complete
+            setTimeout(() => {
+                closeNav();
+            }, 300);
+        });
+    });
+    
+    // Close nav on window resize (if resizing to desktop)
+    window.addEventListener('resize', () => {
+        if (window.innerWidth > 768) {
+            closeNav();
+        }
+    });
+}


### PR DESCRIPTION
## Summary
Splits the monolithic `app.ts` (1,545 lines) into 10 focused modules under `src/`. Pure refactor — no behavior changes.

Closes #2

## Module breakdown

| Module | Responsibility |
|--------|---------------|
| `src/types.ts` | Shared types & interfaces (HandAction, HandCell, SavedRange, Preset, etc.) |
| `src/constants.ts` | RANKS, STORAGE_KEY, INITIAL_HANDS_COUNT |
| `src/state.ts` | All mutable app state (handsState, drag state, mode state, training state) |
| `src/actions.ts` | Core hand actions: setHandAction, setEditMode, resetAll, selectAll, updateStats |
| `src/grid.ts` | Grid rendering: getHandInfo, createRangeGrid |
| `src/presets.ts` | Preset loading & rendering from presets.json |
| `src/storage.ts` | localStorage save/load/delete, clipboard export, getCurrentSelection |
| `src/training.ts` | All training modes: range recall, spot drill, card display |
| `src/ui.ts` | Toast notifications, confirm modals, mobile nav |
| `src/app.ts` | Entry point: setupNavigation, init, event wiring |

## Build setup
- Added **esbuild** as bundler — bundles all `src/*.ts` into a single `app.js` (IIFE format, ES2015 target)
- `npm run build` — one-shot build
- `npm run watch` — rebuild on file changes
- Updated GitHub Actions deploy workflow to run `npm ci && npm run build` before deploy
- `index.html` unchanged — still loads `app.js` directly

## How to verify
1. `npm install && npm run build`
2. Open `index.html` in browser
3. Everything should work identically: grid, drag-to-paint, presets, save/load, training modes, spot drill
4. Check GitHub Actions deploys successfully after merge